### PR TITLE
Adds functionality to update homebrew tap README project table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.5.0 (NEXT UPDATE)
+
+* Adds a feature to update the project table in the homebrew tap's README which includes all the formula name, descriptions, and installation commands
+* Drops the clone depth of a repo from 5 to 2
+* Changes the git config from a global scope to local scope (helps during testing by not accidentally blowing away real credentials)
+* Various code refactor
+
 ## v0.4.3 (2021-02-01)
 
 * Added automated releasing (retagging) of Homebrew Releaser via GitHub Actions. When a new version is released, GitHub Actions will automatically update the stable `v1` tag to point to the latest release

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ test:
 
 ## coverage - Test the project and generate an HTML coverage report
 coverage:
-	venv/bin/pytest --cov=homebrew_releaser --cov-branch --cov-report=html
+	venv/bin/pytest --cov=homebrew_releaser --cov-branch --cov-report=html --cov-report=term-missing
 
 .PHONY: help install clean lint test coverage

--- a/README.md
+++ b/README.md
@@ -67,9 +67,27 @@ jobs:
           # Optional.
           test: 'assert_match("my script output", shell_output("my-script-command"))'
 
-          # Skips committing the generated formula to a homebrew tap (useful for local testing)
+          # Skips committing the generated formula to a homebrew tap (useful for local testing).
           # Default is shown.
           skip_commit: false
+
+          # Update your homebrew tap's README with a table of all projects in the tap.
+          # This is done by pulling the information from all your formula.rb files - eg:
+          #
+          # | Project                                    | Description  | Installation             |
+          # | ------------------------------------------ | ------------ | ------------------------ |
+          # | [formula_1](https://github.com/user/repo1) | helpful text | `brew install formula_1` |
+          # | [formula_1](https://github.com/user/repo2) | helpful text | `brew install formula_2` |
+          # | [formula_1](https://github.com/user/repo3) | helpful text | `brew install formula_3` |
+          #
+          # Simply place the following in your README or wrap your project in these comment tags:
+          # <!-- project_table_start -->
+          # TABLE HERE
+          # <!--project_table_end -->
+          #
+          # Finally, mark `update_readme_table` as `true` in your GitHub Action config and we'll do the work of building a custom table for you.
+          # Default is `false`.
+          update_readme_table: true
 ```
 
 ### Run Manually

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,10 @@ inputs:
     description: "Custom test command for your formula so you can run `brew test`."
     required: false
   skip_commit:
-    description: "Skips committing the generated formula to a homebrew tap (useful for local testing)"
+    description: "Skips committing the generated formula to a homebrew tap (useful for local testing)."
+    required: false
+  update_readme_table:
+    description: "Update your homebrew tap's README with a table of all projects in the tap."
     required: false
 runs:
   using: "docker"
@@ -47,3 +50,4 @@ runs:
     - ${{ inputs.install }}
     - ${{ inputs.test }}
     - ${{ inputs.skip_commit }}
+    - ${{ inputs.update_readme_table }}

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -1,0 +1,6 @@
+import os
+
+# For constants that are required by multiple modules
+
+SUBPROCESS_TIMEOUT = 30
+FORMULA_FOLDER = os.getenv('INPUT_FORMULA_FOLDER', 'formula')

--- a/homebrew_releaser/homebrew_readme_updater.py
+++ b/homebrew_releaser/homebrew_readme_updater.py
@@ -1,0 +1,92 @@
+import os
+import re
+
+from pretty_tables import PrettyTables
+
+
+def main():
+    formulas = format_formula_data()
+    new_table = generate_table(formulas)
+    old_table = retrieve_old_table()
+    readme_content = read_current_readme()
+    replace_table_contents(readme_content, old_table, new_table)
+
+
+def format_formula_data():
+    files = os.listdir('formula')
+    formulas = []
+    for filename in sorted(files):
+        with open('formula/' + filename, 'r') as formula:
+            for i, line in enumerate(formula):
+                if line.strip().startswith('class'):
+                    name_line = line.split()
+                    name_pieces = []
+                    name_pieces = re.findall('[A-Z][^A-Z]*', name_line[1])
+                    formatted_name = ''
+
+                    for piece in name_pieces:
+                        if piece != name_pieces[-1]:
+                            formatted_name += f'{piece}-'
+                        else:
+                            formatted_name += f'{piece}'
+                        final_name = formatted_name.lower()
+                if line.strip().startswith('desc'):
+                    final_desc = line.strip().replace('desc ', '').replace('"', '')
+                if line.strip().startswith('homepage'):
+                    final_homepage = line.strip().replace('homepage ', '').replace('"', '')
+            formula_data = {
+                'name': final_name,
+                'desc': final_desc,
+                'homepage': final_homepage,
+            }
+            formulas.append(formula_data)
+    return formulas
+
+
+def generate_table(formulas):
+    headers = ['Project', 'Description', 'Installation']
+    rows = []
+    for formula in formulas:
+        rows.append(
+            [f'[{formula["name"]}]({formula.get("homepage")})', formula.get(
+                'desc'), f'`brew install {formula["name"]}`']
+        )
+
+    table = PrettyTables.generate_table(
+        headers=headers,
+        rows=rows,
+        empty_cell_placeholder='NA',
+    )
+
+    return table
+
+
+def retrieve_old_table():
+    with open('README.md', 'r') as infile:
+        copy = False
+        old_table = ''
+        for line in infile:
+            if line.strip() == '<!-- project_table_start -->':
+                copy = True
+                continue
+            elif line.strip() == '<!-- project_table_end -->':
+                copy = False
+                continue
+            elif copy:
+                old_table += line
+        return old_table
+
+
+def read_current_readme():
+    with open('README.md', 'r') as infile:
+        file_content = infile.read()
+        return file_content
+
+
+def replace_table_contents(file_content, old_table, new_table):
+    with open('README.md', 'w') as outfile:
+        outfile.write(file_content.replace(old_table, new_table + '\n'))
+
+
+if __name__ == '__main__':
+    main()

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -95,6 +95,7 @@ def retrieve_old_table():
 
         # If we start copying but never find a closing tag or can't copy the old table content, raise an error
         if copy is True or old_table == '':
+            # TODO: Do we want to exit here or simply log a warning?
             raise SystemExit('Could not find start/end tags for project table in README.')
 
         return old_table

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -4,7 +4,7 @@ import re
 from pretty_tables import PrettyTables
 
 
-def main():
+def update_readme():
     formulas = format_formula_data()
     new_table = generate_table(formulas)
     old_table = retrieve_old_table()
@@ -16,7 +16,7 @@ def format_formula_data():
     files = os.listdir('formula')
     formulas = []
     for filename in sorted(files):
-        with open('formula/' + filename, 'r') as formula:
+        with open('formula/' + filename, 'r') as formula:  # TODO: Allow this /formula dir to be editable by the user
             for i, line in enumerate(formula):
                 if line.strip().startswith('class'):
                     name_line = line.split()
@@ -48,8 +48,11 @@ def generate_table(formulas):
     rows = []
     for formula in formulas:
         rows.append(
-            [f'[{formula["name"]}]({formula.get("homepage")})', formula.get(
-                'desc'), f'`brew install {formula["name"]}`']
+            [
+                f'[{formula["name"]}]({formula.get("homepage")})',
+                formula.get('desc'),
+                f'`brew install {formula["name"]}`',
+            ]
         )
 
     table = PrettyTables.generate_table(
@@ -66,10 +69,11 @@ def retrieve_old_table():
         copy = False
         old_table = ''
         for line in infile:
-            if line.strip() == '<!-- project_table_start -->':
+            # TODO: Add exception handling when these aren't present but the user asked to update the README
+            if line.strip() == '<!-- project_table_start -->':  # TODO: Allow these strings to be configured by the user
                 copy = True
                 continue
-            elif line.strip() == '<!-- project_table_end -->':
+            elif line.strip() == '<!-- project_table_end -->':  # TODO: Allow these strings to be configured by the user
                 copy = False
                 continue
             elif copy:
@@ -86,7 +90,3 @@ def read_current_readme():
 def replace_table_contents(file_content, old_table, new_table):
     with open('README.md', 'w') as outfile:
         outfile.write(file_content.replace(old_table, new_table + '\n'))
-
-
-if __name__ == '__main__':
-    main()

--- a/homebrew_releaser/releaser.py
+++ b/homebrew_releaser/releaser.py
@@ -5,6 +5,8 @@ import subprocess
 
 import requests
 
+from homebrew_releaser.readme_updater import update_readme
+
 GITHUB_BASE_URL = 'https://api.github.com'
 GITHUB_HEADERS = {
     'accept': 'application/vnd.github.v3+json',
@@ -30,6 +32,7 @@ COMMIT_EMAIL = os.getenv('INPUT_COMMIT_EMAIL', 'homebrew-releaser@example.com')
 FORMULA_FOLDER = os.getenv('INPUT_FORMULA_FOLDER', 'formula')
 TEST = os.getenv('INPUT_TEST')
 SKIP_COMMIT = os.getenv('INPUT_SKIP_COMMIT', False)
+UPDATE_README_TABLE = os.getenv('UPDATE_README_TABLE')
 
 
 def run_github_action():
@@ -68,8 +71,11 @@ def run_github_action():
         logging.info(f'Skipping commit to {HOMEBREW_TAP}.')
     else:
         logging.info(f'Attempting to release {version} of {GITHUB_REPO} to {HOMEBREW_TAP}...')
-        commit_formula(COMMIT_OWNER, COMMIT_EMAIL, HOMEBREW_OWNER,
-                       HOMEBREW_TAP, FORMULA_FOLDER, GITHUB_REPO, version)
+        setup_git(COMMIT_OWNER, COMMIT_EMAIL, HOMEBREW_OWNER, HOMEBREW_TAP)
+        if UPDATE_README_TABLE:
+            update_readme()
+            # TODO: We need to add the updated README to the files to be committed
+        commit_formula(HOMEBREW_OWNER, HOMEBREW_TAP, FORMULA_FOLDER, GITHUB_REPO, version)
         logging.info(f'Successfully released {version} of {GITHUB_REPO} to {HOMEBREW_TAP}!')
 
 
@@ -198,26 +204,47 @@ class {class_name} < Formula
     return template
 
 
-def commit_formula(commit_owner, commit_email, homebrew_owner, homebrew_tap,
-                   formula_folder, repo_name, version):
-    """Commits the new formula to the specified Homebrew tap
+def setup_git(commit_owner, commit_email, homebrew_owner, homebrew_tap):
+    """Sets up the git environment we'll need to commit our changes to the
+    homebrew tap.
 
     1) Set global git config for the commit
     2) Clone the Homebrew tap repo
-    3) Move our generated formula into the homebrew tap repo
-    4) Commit and push the updated formula file to the repo
     """
     try:
         output = subprocess.check_output(
             (
-                f'git config --global user.name "{commit_owner}" && '
-                f'git config --global user.email {commit_email} && '
-                f'git clone --depth=5 https://{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git && '
-                f'mv {repo_name}.rb {homebrew_tap}/{formula_folder}/{repo_name}.rb && '
-                f'cd {homebrew_tap} && '
-                f'git add {formula_folder}/{repo_name}.rb && '
-                f'git commit -m "Brew formula update for {repo_name} version {version}" && '
-                f'git push https://{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git'
+                f'git config --global user.name "{commit_owner}"'
+                f' && git config --global user.email {commit_email}'
+                f' && git clone --depth=2 https://{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git'
+            ),
+            stdin=None,
+            stderr=None,
+            shell=True,
+            timeout=SUBPROCESS_TIMEOUT
+        )
+        logging.debug('Git environment setup successfully.')
+    except subprocess.TimeoutExpired as error:
+        raise SystemExit(error)
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error)
+    return output
+
+
+def commit_formula(homebrew_owner, homebrew_tap, formula_folder, repo_name, version):
+    """Commits the new formula to the specified Homebrew tap
+
+    1) Move our generated formula into the homebrew tap repo
+    2) Commit and push the updated formula file to the repo
+    """
+    try:
+        output = subprocess.check_output(
+            (
+                f'mv {repo_name}.rb {homebrew_tap}/{formula_folder}/{repo_name}.rb'
+                f' && cd {homebrew_tap}'
+                f' && git add {formula_folder}/{repo_name}.rb'
+                f' && git commit -m "Brew formula update for {repo_name} version {version}"'
+                f' && git push https://{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git'
             ),
             stdin=None,
             stderr=None,

--- a/homebrew_releaser/releaser.py
+++ b/homebrew_releaser/releaser.py
@@ -31,7 +31,7 @@ COMMIT_OWNER = os.getenv('INPUT_COMMIT_OWNER', 'homebrew-releaser')
 COMMIT_EMAIL = os.getenv('INPUT_COMMIT_EMAIL', 'homebrew-releaser@example.com')
 TEST = os.getenv('INPUT_TEST')
 SKIP_COMMIT = os.getenv('INPUT_SKIP_COMMIT', False)
-UPDATE_README_TABLE = os.getenv('UPDATE_README_TABLE')
+UPDATE_README_TABLE = os.getenv('INPUT_UPDATE_README_TABLE')
 
 
 def run_github_action():

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 REQUIREMENTS = [
-    'requests >= 1.0.0'
+    'requests >= 1.0.0',
+    'pretty_tables >= 1.1.0',
 ]
 
 setuptools.setup(
     name='homebrew-releaser',
-    version='0.4.3',
+    version='0.5.0',
     description='Release scripts, binaries, and executables directly to Homebrew via GitHub Actions.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/unit/test_releaser.py
+++ b/test/unit/test_releaser.py
@@ -13,6 +13,7 @@ from homebrew_releaser.releaser import (GITHUB_HEADERS, SUBPROCESS_TIMEOUT,
 
 
 @mock.patch('logging.info')
+@mock.patch('homebrew_releaser.releaser.setup_git')
 @mock.patch('homebrew_releaser.releaser.commit_formula')
 @mock.patch('homebrew_releaser.releaser.write_file')
 @mock.patch('homebrew_releaser.releaser.generate_formula')
@@ -22,7 +23,7 @@ from homebrew_releaser.releaser import (GITHUB_HEADERS, SUBPROCESS_TIMEOUT,
 @mock.patch('homebrew_releaser.releaser.check_required_env_variables')
 def test_run_github_action(mock_check_env_variables, mock_make_get_request, mock_get_latest_tar_archive,
                            mock_get_checksum, mock_generate_formula, mock_write_file, mock_commit_formula,
-                           mock_logger):
+                           mock_setup_git, mock_logger):
     # TODO: Assert these `called_with` eventually
     run_github_action()
     assert mock_logger.call_count == 6
@@ -174,38 +175,32 @@ def test_generate_formula():
 @mock.patch('subprocess.check_output')
 def test_commit_formula(mock_subprocess):
     # TODO: Mock the subprocess better to ensure it does what it's supposed to
-    commit_owner = 'Justintime50'
-    commit_email = 'justin@example.com'
     homebrew_owner = 'Justintime50'
     homebrew_tap = 'homebrew-formulas'
     formula_folder = 'formula'
     repo_name = 'repo-name'
     version = 'v0.1.0'
-    commit_formula(commit_owner, commit_email, homebrew_owner, homebrew_tap, formula_folder, repo_name, version)
+    commit_formula(homebrew_owner, homebrew_tap, formula_folder, repo_name, version)
     mock_subprocess.assert_called_once()  # TODO: Should we assert a `called_with` here since it's SO long?
 
 
 @mock.patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd=subprocess.check_output, timeout=0.1))  # noqa
 def test_commit_formula_subprocess_timeout(mock_subprocess):
-    commit_owner = 'Justintime50'
-    commit_email = 'justin@example.com'
     homebrew_owner = 'Justintime50'
     homebrew_tap = 'homebrew-formulas'
     formula_folder = 'formula'
     repo_name = 'repo-name'
     version = 'v0.1.0'
     with pytest.raises(SystemExit):
-        commit_formula(commit_owner, commit_email, homebrew_owner, homebrew_tap, formula_folder, repo_name, version)
+        commit_formula(homebrew_owner, homebrew_tap, formula_folder, repo_name, version)
 
 
 @mock.patch('subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd=subprocess.check_output))  # noqa
 def test_commit_formula_process_error(mock_subprocess):
-    commit_owner = 'Justintime50'
-    commit_email = 'justin@example.com'
     homebrew_owner = 'Justintime50'
     homebrew_tap = 'homebrew-formulas'
     formula_folder = 'formula'
     repo_name = 'repo-name'
     version = 'v0.1.0'
     with pytest.raises(SystemExit):
-        commit_formula(commit_owner, commit_email, homebrew_owner, homebrew_tap, formula_folder, repo_name, version)
+        commit_formula(homebrew_owner, homebrew_tap, formula_folder, repo_name, version)


### PR DESCRIPTION
This PR adds the ability to update a tap's project table in the README (see https://github.com/Justintime50/homebrew-formulas/issues/2).

By adding a simple `start/end` comment tag around your README table, we can then update the README table whenever the homebrew-releaser flow kicks off (assuming the user elected to update the README as this feature will be completely optional and opinionated.)

The new table will contain the project name and link to the homepage, the project description, and the installation instruction (assumed).

This will be a great feature to help automate the complete releasing flow of any Homebrew project.