### PR TITLE
feat: adds a checksum.txt file to the latest release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.7", "3.8", "3.9", "3.10"]
+        pythonversion: ["3.9", "3.10"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.10.0 (TODO)
+
+* Adds a `checksum.txt` file to the latest release of your repo containing the checksums of all "released" assets (binaries, scripts, etc)
+
 ## v0.9.2 (2021-12-07)
 
 * Adds `mypy` type checking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v0.10.0 (TODO)
+## v0.10.0 (2021-12-12)
 
 * Adds a `checksum.txt` file to the latest release of your repo containing the checksums of all "released" assets (binaries, scripts, etc)
+* Bumps minimum version of Python from 3.7 to 3.9
 
 ## v0.9.2 (2021-12-07)
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -58,7 +58,7 @@ class App:
         repository = Utils.make_get_request(f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}', False).json()
         tags = Utils.make_get_request(f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}/tags', False).json()
         version = tags[0]['name']
-        logger.info(f'Latest release of {version} successfully identified...')
+        logger.info(f'Latest release ({version}) successfully identified...')
 
         logger.info('Generating tar archive checksum(s)...')
         auto_generated_release_tar = f'https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}/archive/{version}.tar.gz'

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -1,17 +1,25 @@
 import subprocess
+from typing import Tuple
 
+import requests
 import woodchips
 
-from homebrew_releaser.constants import LOGGER_NAME, SUBPROCESS_TIMEOUT
+from homebrew_releaser.constants import (
+    GITHUB_OWNER,
+    GITHUB_REPO,
+    GITHUB_TOKEN,
+    LOGGER_NAME,
+    SUBPROCESS_TIMEOUT,
+)
+from homebrew_releaser.utils import Utils
 
 
 class Checksum:
     @staticmethod
-    def get_checksum(tar_filepath: str) -> str:
+    def get_checksum(tar_filepath: str) -> Tuple[str, str]:
         """Gets the checksum of a file."""
         logger = woodchips.get(LOGGER_NAME)
 
-        # TODO: Create and upload a `checksums.txt` file to the release for the zip and tar archives
         try:
             command = ['shasum', '-a', '256', tar_filepath]
             output = subprocess.check_output(
@@ -21,11 +29,39 @@ class Checksum:
                 timeout=SUBPROCESS_TIMEOUT,
             )
             checksum = output.decode().split()[0]
-            checksum_file = output.decode().split()[1]  # TODO: Use this to craft the `checksums.txt` file  # noqa
+            checksum_file = output.decode().split()[1]
             logger.debug(f'Checksum generated successfully: {checksum}')
         except subprocess.TimeoutExpired as error:
             raise SystemExit(error)
         except subprocess.CalledProcessError as error:
             raise SystemExit(error)
 
-        return checksum
+        return checksum, checksum_file
+
+    @staticmethod
+    def upload_checksum_file():
+        """Uploads a `checksum.txt` file to the latest release of the repo."""
+        checksum_file = 'checksum.txt'  # This file was created elsewhere
+
+        latest_release_url = f'https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest'
+        latest_release_response = Utils.make_get_request(latest_release_url)
+        latest_release_id = latest_release_response.json()['id']
+
+        with open('checksum.txt', 'rb') as filename:
+            checksum_binary = filename.read()
+
+        upload_url = f'https://uploads.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/{latest_release_id}/assets?name={checksum_file}'  # noqa
+        headers = {
+            'Authorization': f'token {GITHUB_TOKEN}',
+            'Accept': 'application/vnd.github.v3+json',
+            'Content-Type': 'text/plain',
+        }
+
+        try:
+            _ = requests.post(
+                upload_url,
+                headers=headers,
+                data=checksum_binary,
+            )
+        except requests.exceptions.RequestException as error:
+            raise SystemExit(error)

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -41,6 +41,8 @@ class Checksum:
     @staticmethod
     def upload_checksum_file():
         """Uploads a `checksum.txt` file to the latest release of the repo."""
+        logger = woodchips.get(LOGGER_NAME)
+
         checksum_file = 'checksum.txt'  # This file was created elsewhere
 
         latest_release_url = f'https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest'
@@ -63,5 +65,6 @@ class Checksum:
                 headers=headers,
                 data=checksum_binary,
             )
+            logger.info(f'checksum.txt uploaded successfully to {GITHUB_REPO}.')
         except requests.exceptions.RequestException as error:
             raise SystemExit(error)

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -3,6 +3,8 @@ import os
 # User Input
 FORMULA_FOLDER = os.getenv('INPUT_FORMULA_FOLDER', 'formula')
 GITHUB_TOKEN = os.getenv('INPUT_GITHUB_TOKEN')
+HOMEBREW_TAP = os.getenv('INPUT_HOMEBREW_TAP')
+SKIP_COMMIT = os.getenv('INPUT_SKIP_COMMIT', False)
 
 # App Constants
 LOGGER_NAME = 'homebrew-releaser'
@@ -12,3 +14,8 @@ GITHUB_HEADERS = {
     'agent': 'Homebrew Releaser',
 }
 TAR_ARCHIVE = 'tar_archive.tar.gz'
+
+# GitHub Action env variables set by GitHub
+GITHUB_REPOSITORY = os.getenv('GITHUB_REPOSITORY', 'user/repo').split('/')
+GITHUB_OWNER = GITHUB_REPOSITORY[0]
+GITHUB_REPO = GITHUB_REPOSITORY[1]

--- a/homebrew_releaser/formula.py
+++ b/homebrew_releaser/formula.py
@@ -41,8 +41,13 @@ class Formula:
         description = re.sub(r'[.!]+', '', repository['description'][:description_length]).strip().capitalize()
 
         # If the first word of the desc is an article, we cut it out per `brew audit`
+        articles = {
+            'a',
+            'an',
+            'the',
+        }
         first_word_of_desc = description.split(' ', 1)
-        if first_word_of_desc[0].lower() in ['a', 'an', 'the']:
+        if first_word_of_desc[0].lower() in articles:
             description = first_word_of_desc[1].strip().capitalize()
 
         # RUBY TEMPLATE DATA TO REMAIN DOUBLE SPACED

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -25,13 +25,13 @@ class Utils:
         return response
 
     @staticmethod
-    def write_file(filename: str, content: bytes, mode: str = 'w'):
+    def write_file(file_path: str, content: bytes, mode: str = 'w'):
         """Writes content to a file."""
         logger = woodchips.get(LOGGER_NAME)
 
         try:
-            with open(filename, mode) as f:
+            with open(file_path, mode) as f:
                 f.write(content)
-            logger.debug(f'{filename} written successfully.')
+            logger.debug(f'{file_path} written successfully.')
         except Exception as error:
             raise SystemExit(error)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ DEV_REQUIREMENTS = [
 
 setuptools.setup(
     name='homebrew-releaser',
-    version='0.9.2',
+    version='0.10.0',
     description='Release scripts, binaries, and executables directly to Homebrew via GitHub Actions.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,5 @@ setuptools.setup(
             'homebrew-releaser=homebrew_releaser.releaser:main',
         ]
     },
-    python_requires='>=3.7, <4',
+    python_requires='>=3.9, <4',
 )

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import pytest
 
 
@@ -10,8 +8,9 @@ def mock_tar_filename():
 
 @pytest.fixture
 def mock_git_repo():
-    mock_git_repo = MagicMock()
-    mock_git_repo.id = '123'
-    mock_git_repo.name = 'mock-repo-name'
+    mock_git_repo = {
+        'id': '123',
+        'name': 'mock-repo-name',
+    }
 
     return mock_git_repo

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -4,13 +4,3 @@ import pytest
 @pytest.fixture
 def mock_tar_filename():
     return 'mock-file.tar.gz'
-
-
-@pytest.fixture
-def mock_git_repo():
-    mock_git_repo = {
-        'id': '123',
-        'name': 'mock-repo-name',
-    }
-
-    return mock_git_repo

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,6 +1,17 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 
 @pytest.fixture
 def mock_tar_filename():
     return 'mock-file.tar.gz'
+
+
+@pytest.fixture
+def mock_git_repo():
+    mock_git_repo = MagicMock()
+    mock_git_repo.id = '123'
+    mock_git_repo.name = 'mock-repo-name'
+
+    return mock_git_repo

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -14,13 +14,13 @@ from homebrew_releaser.app import App
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
 @patch('homebrew_releaser.checksum.Checksum.get_checksum')
-@patch('homebrew_releaser.app.App.download_latest_tar_archive')
+@patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
 def test_run_github_action_skip_commit(
     mock_check_env_variables,
     mock_make_get_request,
-    mock_download_latest_tar_archive,
+    mock_download_tar_archive,
     mock_get_checksum,
     mock_generate_formula,
     mock_write_file,
@@ -36,7 +36,7 @@ def test_run_github_action_skip_commit(
     mock_logger.assert_called()
     mock_check_env_variables.assert_called_once()
     assert mock_make_get_request.call_count == 2
-    mock_download_latest_tar_archive.assert_called_once()
+    mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
     mock_write_file.assert_called_once()
@@ -53,14 +53,14 @@ def test_run_github_action_skip_commit(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum')
-@patch('homebrew_releaser.app.App.download_latest_tar_archive')
+@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'filename'))
+@patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
 def test_run_github_action(
     mock_check_env_variables,
     mock_make_get_request,
-    mock_download_latest_tar_archive,
+    mock_download_tar_archive,
     mock_get_checksum,
     mock_generate_formula,
     mock_write_file,
@@ -76,7 +76,7 @@ def test_run_github_action(
     mock_logger.assert_called()
     mock_check_env_variables.assert_called_once()
     assert mock_make_get_request.call_count == 2
-    mock_download_latest_tar_archive.assert_called_once()
+    mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
     mock_write_file.assert_called_once()
@@ -96,13 +96,13 @@ def test_run_github_action(
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
 @patch('homebrew_releaser.checksum.Checksum.get_checksum')
-@patch('homebrew_releaser.app.App.download_latest_tar_archive')
+@patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
 def test_run_github_action_update_readme(
     mock_check_env_variables,
     mock_make_get_request,
-    mock_download_latest_tar_archive,
+    mock_download_tar_archive,
     mock_get_checksum,
     mock_generate_formula,
     mock_write_file,
@@ -119,7 +119,7 @@ def test_run_github_action_update_readme(
     mock_logger.assert_called()
     mock_check_env_variables.assert_called_once()
     assert mock_make_get_request.call_count == 2
-    mock_download_latest_tar_archive.assert_called_once()
+    mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
     mock_write_file.assert_called_once()
@@ -162,9 +162,9 @@ def test_check_required_env_variables_missing_env_variable(mock_system_exit):
 
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
-def test_download_latest_tar_archive(mock_make_get_request, mock_write_file):
+def test_download_tar_archive(mock_make_get_request, mock_write_file):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser/archive/v0.1.0.tar.gz'
-    App.download_latest_tar_archive(url)
+    App.download_tar_archive(url)
 
     mock_make_get_request.assert_called_once_with(url, True)
     mock_write_file.assert_called_once()  # TODO: Assert `called_with` here instead

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -32,7 +32,6 @@ def test_run_github_action_skip_commit(
     mock_logger,
 ):
     App.run_github_action()
-    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()
@@ -76,7 +75,6 @@ def test_run_github_action(
     mock_upload_checksum_file,
 ):
     App.run_github_action()
-    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()
@@ -123,7 +121,6 @@ def test_run_github_action_update_readme(
     mock_update_readme,
 ):
     App.run_github_action()
-    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -6,6 +6,7 @@ from homebrew_releaser.app import App
 
 
 @patch('homebrew_releaser.app.SKIP_COMMIT', True)
+@patch('homebrew_releaser.app.HOMEBREW_TAP', '123')
 @patch('woodchips.get')
 @patch('homebrew_releaser.git.Git.setup')
 @patch('homebrew_releaser.git.Git.add')
@@ -13,7 +14,7 @@ from homebrew_releaser.app import App
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum')
+@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -39,13 +40,15 @@ def test_run_github_action_skip_commit(
     mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
-    mock_write_file.assert_called_once()
+    mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
     mock_add_formula.assert_not_called()
     mock_commit_formula.assert_not_called()
     mock_push_formula.assert_not_called()
 
 
+@patch('homebrew_releaser.app.HOMEBREW_TAP', '123')
+@patch('homebrew_releaser.checksum.Checksum.upload_checksum_file')
 @patch('woodchips.get')
 @patch('homebrew_releaser.git.Git.setup')
 @patch('homebrew_releaser.git.Git.add')
@@ -53,7 +56,7 @@ def test_run_github_action_skip_commit(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'filename'))
+@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -69,6 +72,7 @@ def test_run_github_action(
     mock_add_formula,
     mock_setup_git,
     mock_logger,
+    mock_upload_checksum_file,
 ):
     App.run_github_action()
 
@@ -79,15 +83,17 @@ def test_run_github_action(
     mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
-    mock_write_file.assert_called_once()
+    mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
     mock_add_formula.assert_called_once()
     mock_commit_formula.assert_called_once()
     mock_push_formula.assert_called_once()
 
 
+@patch('homebrew_releaser.app.HOMEBREW_TAP', '123')
 @patch('homebrew_releaser.app.UPDATE_README_TABLE', True)
 @patch('homebrew_releaser.readme_updater.ReadmeUpdater.update_readme')
+@patch('homebrew_releaser.checksum.Checksum.upload_checksum_file')
 @patch('woodchips.get')
 @patch('homebrew_releaser.git.Git.setup')
 @patch('homebrew_releaser.git.Git.add')
@@ -95,7 +101,7 @@ def test_run_github_action(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum')
+@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_tar_archive')
 @patch('homebrew_releaser.utils.Utils.make_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -111,6 +117,7 @@ def test_run_github_action_update_readme(
     mock_add_formula,
     mock_setup_git,
     mock_logger,
+    mock_upload_checksum_file,
     mock_update_readme,
 ):
     App.run_github_action()
@@ -122,7 +129,7 @@ def test_run_github_action_update_readme(
     mock_download_tar_archive.assert_called_once()
     mock_get_checksum.assert_called_once()
     mock_generate_formula.assert_called_once()
-    mock_write_file.assert_called_once()
+    mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
     mock_add_formula.assert_called_once()
     mock_commit_formula.assert_called_once()

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -32,6 +32,7 @@ def test_run_github_action_skip_commit(
     mock_logger,
 ):
     App.run_github_action()
+    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()
@@ -75,6 +76,7 @@ def test_run_github_action(
     mock_upload_checksum_file,
 ):
     App.run_github_action()
+    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()
@@ -121,6 +123,7 @@ def test_run_github_action_update_readme(
     mock_update_readme,
 ):
     App.run_github_action()
+    mock_make_get_request.return_value = {'name': 'mock-repo'}
 
     # TODO: Assert these `called_with` eventually
     mock_logger.assert_called()

--- a/test/unit/test_checksum.py
+++ b/test/unit/test_checksum.py
@@ -1,7 +1,8 @@
 import subprocess
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 import pytest
+import requests
 
 from homebrew_releaser.checksum import Checksum
 from homebrew_releaser.constants import SUBPROCESS_TIMEOUT
@@ -32,3 +33,29 @@ def test_get_checksum_subprocess_timeout(mock_subprocess, mock_tar_filename):
 def test_get_checksum_process_error(mock_subprocess, mock_tar_filename):
     with pytest.raises(SystemExit):
         Checksum.get_checksum(mock_tar_filename)
+
+
+@patch('requests.post')
+@patch('homebrew_releaser.utils.Utils.make_get_request')
+def test_upload_checksum_file(mock_make_get_request, mock_post_request):
+    """Tests that we make the GET call to retrieve the latest release and the
+    POST call to upload the checksum.txt file.
+    """
+    with patch('builtins.open', mock_open()):
+        Checksum.upload_checksum_file()
+
+        mock_make_get_request.assert_called_once()
+        mock_post_request.assert_called_once()
+
+
+@patch('requests.post', side_effect=requests.exceptions.RequestException('mock-error'))
+@patch('homebrew_releaser.utils.Utils.make_get_request')
+def test_upload_checksum_file_error_on_upload(mock_make_get_request, mock_post_request):
+    """Tests that we exit on error to upload checksum.txt file."""
+    with patch('builtins.open', mock_open()):
+        with pytest.raises(SystemExit) as error:
+            Checksum.upload_checksum_file()
+
+            mock_make_get_request.assert_called_once()
+            mock_post_request.assert_called_once()
+            assert 'mock-error' == str(error.value)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -18,8 +18,10 @@ def test_make_get_request(mock_request):
 @patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))
 def test_make_get_request_exception(mock_request):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser'
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as error:
         Utils.make_get_request(url, False)
+
+        assert 'mock-error' == str(error.value)
 
 
 def test_write_file():


### PR DESCRIPTION
* Adds a `checksum.txt` file to the latest release of your repo containing the checksums of all "released" assets (binaries, scripts, etc).

TODO:
- [x] End-to-end test this function standalone
- [x] End-to-end test this completely
- [x] Add a unit test for the `upload_checksum_file` function

Lays the groundwork for introducing the ability to specify multiple tar URLs via #9 