### PR TITLE
feat: add support for private repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Add support for private repos by using the `GITHUB_TOKEN` env var available to GitHub Actions to make the HTTP request to the repo in question
+
 ## v0.14.3 (2023-01-31)
 
 - Bumps image from Python 3.10 to 3.11

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ jobs:
           # Default is shown - string
           formula_folder: formula
 
-          # The GitHub Token (saved as a repo secret) that has `repo` permissions for the homebrew tap you want to release to.
+          # The Personal Access Token (saved as a repo secret) that has `repo` permissions for the repo running the action AND Homebrew tap you want to release to.
           # Required - string
-          github_token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
           # Git author info used to commit to the homebrew tap.
           # Defaults are shown - strings

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -65,14 +65,8 @@ class App:
         Git.setup(COMMIT_OWNER, COMMIT_EMAIL, HOMEBREW_OWNER, HOMEBREW_TAP)
 
         logger.info(f'Collecting data about {GITHUB_REPO}...')
-        repository = Utils.make_get_request(
-            url=f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}',
-            stream=False,
-        ).json()
-        tags = Utils.make_get_request(
-            url=f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}/tags',
-            stream=False,
-        ).json()
+        repository = Utils.make_get_request(url=f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}').json()
+        tags = Utils.make_get_request(url=f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}/tags').json()
         version = tags[0]['name']
         version_no_v = version.replace('v', '')
         logger.info(f'Latest release ({version}) successfully identified!')
@@ -186,7 +180,10 @@ class App:
     @staticmethod
     def download_archive(url: str) -> str:
         """Gets an archive (eg: zip, tar) from GitHub and saves it locally."""
-        response = Utils.make_get_request(url, True)
+        response = Utils.make_get_request(
+            url=url,
+            stream=True,
+        )
         filename = url.rsplit('/', 1)[1]
         Utils.write_file(filename, response.content, 'wb')
 

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -44,7 +44,7 @@ class Checksum:
         logger = woodchips.get(LOGGER_NAME)
 
         latest_release_url = f'https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest'
-        latest_release_response = Utils.make_get_request(latest_release_url)
+        latest_release_response = Utils.make_get_request(url=latest_release_url)
         latest_release_id = latest_release_response.json()['id']
 
         with open(CHECKSUM_FILE, 'rb') as filename:

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -15,6 +15,7 @@ SUBPROCESS_TIMEOUT = 30
 GITHUB_HEADERS = {
     'accept': 'application/vnd.github.v3+json',
     'agent': 'Homebrew Releaser',
+    'Authorization': f'Bearer {GITHUB_TOKEN}',
 }
 CHECKSUM_FILE = 'checksum.txt'
 

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -221,5 +221,5 @@ def test_download_archive(mock_make_get_request, mock_write_file):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser/archive/v0.1.0.tar.gz'
     App.download_archive(url)
 
-    mock_make_get_request.assert_called_once_with(url, True)
+    mock_make_get_request.assert_called_once_with(url=url, stream=True)
     mock_write_file.assert_called_once()  # TODO: Assert `called_with` here instead

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -13,7 +13,7 @@ from homebrew_releaser.utils import Utils
 @patch('requests.get')
 def test_make_get_request(mock_request):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser'
-    Utils.make_get_request(url, False)
+    Utils.make_get_request(url=url)
 
     mock_request.assert_called_once_with(url, headers=GITHUB_HEADERS, stream=False)
 
@@ -22,7 +22,7 @@ def test_make_get_request(mock_request):
 def test_make_get_request_exception(mock_request):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser'
     with pytest.raises(SystemExit) as error:
-        Utils.make_get_request(url, False)
+        Utils.make_get_request(url=url)
 
     assert 'mock-error' == str(error.value)
 


### PR DESCRIPTION
Adds support for private repos by authenticating requests against the GitHub API with the `GITHUB_TOKEN` already provided.

This should be a safe change to make because up to this point, GitHub didn't allow for fine-grained per-repo tokens which means that whatever tokens people are using in the wild to authenticate with their homebrew taps in this action already had the appropriately scoped permissions so this change shouldn't break previous integrations but instead add support for private repos in addition to being backwards compatible with public repos.

I created a temp private repo and tested this PRs commit hash as the action used there, everything worked out once the authorization header was added.

Closes #26 