### PR TITLE
refactor: subprocess errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Use new helper function to keep all git calls uniform
   - More appropriate error logging and capture
   - Better tests surrounding subprocesses
+- When updating a README table, we now only `git add` once instead of twice
+- Even if you specify `skip_commit`, we will now run `git commit` but will continue to skip the `git push`, this will ensure a more complete dry-run and will help debug committing issues since it now can commit safely without updating a remote repo
 
 ## v0.16.2 (2023-03-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.16.3 (2023-03-16)
+
+- Refactors git subprocess error handling
+  - Sends `stderr` to `stdout` and captures the subprocess error output as text (previously got clobbered)
+  - Returns stack trace
+  - Use new helper function to keep all git calls uniform
+  - More appropriate error logging and capture
+  - Better tests surrounding subprocesses
+
 ## v0.16.2 (2023-03-15)
 
 - Fixes a packaging issue with v0.16.1

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -148,6 +148,7 @@ class App:
         else:
             logger.debug('Skipping update to project README.')
 
+        # Although users can skip a commit, still commit (and don't push) to dry-run a commit
         Git.add(HOMEBREW_TAP)
         Git.commit(HOMEBREW_TAP, GITHUB_REPO, version)
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -148,16 +148,16 @@ class App:
         else:
             logger.debug('Skipping update to project README.')
 
+        Git.add(HOMEBREW_TAP)
+        Git.commit(HOMEBREW_TAP, GITHUB_REPO, version)
+
         if SKIP_COMMIT:
             logger.info(f'Skipping upload of checksum.txt to {HOMEBREW_TAP}.')
-            logger.info(f'Skipping commit to {HOMEBREW_TAP}.')
+            logger.info(f'Skipping push to {HOMEBREW_TAP}.')
         else:
             logger.info(f'Attempting to upload checksum.txt to the latest release of {GITHUB_REPO}...')
             Checksum.upload_checksum_file(latest_release)
-
             logger.info(f'Attempting to release {version} of {GITHUB_REPO} to {HOMEBREW_TAP}...')
-            Git.add(HOMEBREW_TAP)
-            Git.commit(HOMEBREW_TAP, GITHUB_REPO, version)
             Git.push(HOMEBREW_TAP, HOMEBREW_OWNER)
             logger.info(f'Successfully released {version} of {GITHUB_REPO} to {HOMEBREW_TAP}!')
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -40,7 +40,7 @@ class Git:
                     timeout=TIMEOUT,
                 )
             except subprocess.CalledProcessError as error:
-                logger.critical(error.stderr)
+                logger.critical(error.output)
                 raise
 
         logger.debug('Git environment setup successfully.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -36,6 +36,7 @@ class Git:
             subprocess.check_output(  # nosec
                 command,
                 stderr=subprocess.STDOUT,
+                text=True,
                 timeout=TIMEOUT,
             )
 
@@ -50,6 +51,7 @@ class Git:
         subprocess.check_output(  # nosec
             command,
             stderr=subprocess.STDOUT,
+            text=True,
             timeout=TIMEOUT,
         )
         logger.debug('Assets added to git commit successfully.')
@@ -65,6 +67,7 @@ class Git:
         subprocess.check_output(  # nosec
             command,
             stderr=subprocess.STDOUT,
+            text=True,
             timeout=TIMEOUT,
         )
         logger.debug('Assets committed successfully.')
@@ -80,6 +83,7 @@ class Git:
         subprocess.check_output(  # nosec
             command,
             stderr=subprocess.STDOUT,
+            text=True,
             timeout=TIMEOUT,
         )
         logger.debug(f'Assets pushed successfully to {homebrew_tap}.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -33,11 +33,16 @@ class Git:
         ]
 
         for command in commands:
-            subprocess.check_output(  # nosec
-                command,
-                stdin=None,
-                timeout=TIMEOUT,
-            )
+            try:
+                subprocess.check_output(  # nosec
+                    command,
+                    stdin=None,
+                    timeout=TIMEOUT,
+                )
+            except subprocess.CalledProcessError as error:
+                logger.critical(error.stderr)
+                raise
+
         logger.debug('Git environment setup successfully.')
 
     @staticmethod

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -35,6 +35,7 @@ class Git:
         for command in commands:
             subprocess.check_output(  # nosec
                 command,
+                stderr=subprocess.STDOUT,
                 timeout=TIMEOUT,
             )
 
@@ -48,6 +49,7 @@ class Git:
         command = ['git', '-C', homebrew_tap, 'add', '.']
         subprocess.check_output(  # nosec
             command,
+            stderr=subprocess.STDOUT,
             timeout=TIMEOUT,
         )
         logger.debug('Assets added to git commit successfully.')
@@ -62,6 +64,7 @@ class Git:
         # fmt: on
         subprocess.check_output(  # nosec
             command,
+            stderr=subprocess.STDOUT,
             timeout=TIMEOUT,
         )
         logger.debug('Assets committed successfully.')
@@ -76,6 +79,7 @@ class Git:
         # fmt: on
         subprocess.check_output(  # nosec
             command,
+            stderr=subprocess.STDOUT,
             timeout=TIMEOUT,
         )
         logger.debug(f'Assets pushed successfully to {homebrew_tap}.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -21,88 +21,64 @@ class Git:
         """
         logger = woodchips.get(LOGGER_NAME)
 
-        try:
-            commands = [
-                [
-                    'git',
-                    'clone',
-                    '--depth=1',
-                    f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git',
-                ],
-                ['git', '-C', homebrew_tap, 'config', 'user.name', f'"{commit_owner}"'],
-                ['git', '-C', homebrew_tap, 'config', 'user.email', commit_email],
-            ]
+        commands = [
+            [
+                'git',
+                'clone',
+                '--depth=1',
+                f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git',
+            ],
+            ['git', '-C', homebrew_tap, 'config', 'user.name', f'"{commit_owner}"'],
+            ['git', '-C', homebrew_tap, 'config', 'user.email', commit_email],
+        ]
 
-            for command in commands:
-                subprocess.check_output(  # nosec
-                    command,
-                    stdin=None,
-                    stderr=None,
-                    timeout=TIMEOUT,
-                )
-            logger.debug('Git environment setup successfully.')
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(error)
-        except subprocess.CalledProcessError as error:
-            raise SystemExit(error)
+        for command in commands:
+            subprocess.check_output(  # nosec
+                command,
+                stdin=None,
+                timeout=TIMEOUT,
+            )
+        logger.debug('Git environment setup successfully.')
 
     @staticmethod
     def add(homebrew_tap: str):
         """Adds assets to a git commit."""
         logger = woodchips.get(LOGGER_NAME)
 
-        try:
-            command = ['git', '-C', homebrew_tap, 'add', '.']
-            subprocess.check_output(  # nosec
-                command,
-                stdin=None,
-                stderr=None,
-                timeout=TIMEOUT,
-            )
-            logger.debug('Assets added to git commit successfully.')
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(error)
-        except subprocess.CalledProcessError as error:
-            raise SystemExit(error)
+        command = ['git', '-C', homebrew_tap, 'add', '.']
+        subprocess.check_output(  # nosec
+            command,
+            stdin=None,
+            timeout=TIMEOUT,
+        )
+        logger.debug('Assets added to git commit successfully.')
 
     @staticmethod
     def commit(homebrew_tap: str, repo_name: str, version: str):
         """Commits assets to the Homebrew tap (repo)."""
         logger = woodchips.get(LOGGER_NAME)
 
-        try:
-            # fmt: off
-            command = ['git', '-C', homebrew_tap, 'commit', '-m', f'"Brew formula update for {repo_name} version {version}"']  # noqa
-            # fmt: on
-            subprocess.check_output(  # nosec
-                command,
-                stdin=None,
-                stderr=None,
-                timeout=TIMEOUT,
-            )
-            logger.debug('Assets committed successfully.')
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(error)
-        except subprocess.CalledProcessError as error:
-            raise SystemExit(error)
+        # fmt: off
+        command = ['git', '-C', homebrew_tap, 'commit', '-m', f'"Brew formula update for {repo_name} version {version}"']  # noqa
+        # fmt: on
+        subprocess.check_output(  # nosec
+            command,
+            stdin=None,
+            timeout=TIMEOUT,
+        )
+        logger.debug('Assets committed successfully.')
 
     @staticmethod
     def push(homebrew_tap: str, homebrew_owner: str):
         """Pushes assets to the remote Homebrew tap (repo)."""
         logger = woodchips.get(LOGGER_NAME)
 
-        try:
-            # fmt: off
-            command = ['git', '-C', homebrew_tap, 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
-            # fmt: on
-            subprocess.check_output(  # nosec
-                command,
-                stdin=None,
-                stderr=None,
-                timeout=TIMEOUT,
-            )
-            logger.debug(f'Assets pushed successfully to {homebrew_tap}.')
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(error)
-        except subprocess.CalledProcessError as error:
-            raise SystemExit(error)
+        # fmt: off
+        command = ['git', '-C', homebrew_tap, 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
+        # fmt: on
+        subprocess.check_output(  # nosec
+            command,
+            stdin=None,
+            timeout=TIMEOUT,
+        )
+        logger.debug(f'Assets pushed successfully to {homebrew_tap}.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -40,7 +40,7 @@ class Git:
                     timeout=TIMEOUT,
                 )
             except subprocess.CalledProcessError as error:
-                logger.critical(error.output)
+                logger.critical(error.output.decode())
                 raise
 
         logger.debug('Git environment setup successfully.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -35,7 +35,6 @@ class Git:
         for command in commands:
             subprocess.check_output(  # nosec
                 command,
-                stdin=None,
                 timeout=TIMEOUT,
             )
 
@@ -49,7 +48,6 @@ class Git:
         command = ['git', '-C', homebrew_tap, 'add', '.']
         subprocess.check_output(  # nosec
             command,
-            stdin=None,
             timeout=TIMEOUT,
         )
         logger.debug('Assets added to git commit successfully.')
@@ -64,7 +62,6 @@ class Git:
         # fmt: on
         subprocess.check_output(  # nosec
             command,
-            stdin=None,
             timeout=TIMEOUT,
         )
         logger.debug('Assets committed successfully.')
@@ -79,7 +76,6 @@ class Git:
         # fmt: on
         subprocess.check_output(  # nosec
             command,
-            stdin=None,
             timeout=TIMEOUT,
         )
         logger.debug(f'Assets pushed successfully to {homebrew_tap}.')

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -33,12 +33,16 @@ class Git:
         ]
 
         for command in commands:
-            subprocess.check_output(  # nosec
-                command,
-                stderr=subprocess.STDOUT,
-                text=True,
-                timeout=TIMEOUT,
-            )
+            try:
+                subprocess.check_output(  # nosec
+                    command,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=TIMEOUT,
+                )
+            except subprocess.CalledProcessError as error:
+                logger.critical(error.output)
+                raise
 
         logger.debug('Git environment setup successfully.')
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -33,15 +33,11 @@ class Git:
         ]
 
         for command in commands:
-            try:
-                subprocess.check_output(  # nosec
-                    command,
-                    stdin=None,
-                    timeout=TIMEOUT,
-                )
-            except subprocess.CalledProcessError as error:
-                logger.critical(error.output.decode())
-                raise
+            subprocess.check_output(  # nosec
+                command,
+                stdin=None,
+                timeout=TIMEOUT,
+            )
 
         logger.debug('Git environment setup successfully.')
 

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -14,7 +14,6 @@ from homebrew_releaser.constants import (
     FORMULA_FOLDER,
     LOGGER_NAME,
 )
-from homebrew_releaser.git import Git
 
 
 TABLE_START_TAG = '<!-- project_table_start -->'
@@ -179,8 +178,6 @@ class ReadmeUpdater:
             with open(readme, 'w') as readme_contents:
                 readme_contents.write(file_content.replace(old_table, new_table))
             logger.debug(f'{readme} table updated successfully.')
-
-            Git.add(homebrew_tap)
 
     @staticmethod
     def does_readme_exist(homebrew_tap: str) -> Optional[str]:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ DEV_REQUIREMENTS = [
 
 setuptools.setup(
     name='homebrew-releaser',
-    version='0.16.2',
+    version='0.16.3',
     description='Release scripts, binaries, and executables directly to Homebrew via GitHub Actions.',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -42,8 +42,8 @@ def test_run_github_action_skip_commit(
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
-    mock_add_formula.assert_not_called()
-    mock_commit_formula.assert_not_called()
+    mock_add_formula.assert_called_once()
+    mock_commit_formula.assert_called_once()
     mock_push_formula.assert_not_called()
 
 

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -13,6 +13,7 @@ from homebrew_releaser.git import Git
 @patch('homebrew_releaser.git.GITHUB_TOKEN', '123')
 @patch('subprocess.check_output')
 def test_setup(mock_subprocess):
+    """Tests that we call the correct subprocess commands when setting up the git environment."""
     homebrew_owner = 'Justintime50'
     homebrew_tap = 'homebrew-formulas'
     commit_email = 'user@example.com'
@@ -27,79 +28,43 @@ def test_setup(mock_subprocess):
                     '--depth=1',
                     'https://x-access-token:123@github.com/Justintime50/homebrew-formulas.git',
                 ],
-                stdin=None,
+                stderr=-2,
+                text=True,
                 timeout=30,
             ),
             call(
                 ['git', '-C', 'homebrew-formulas', 'config', 'user.name', '"Justintime50"'],
-                stdin=None,
+                stderr=-2,
+                text=True,
                 timeout=30,
             ),
             call(
                 ['git', '-C', 'homebrew-formulas', 'config', 'user.email', 'user@example.com'],
-                stdin=None,
+                stderr=-2,
+                text=True,
                 timeout=30,
             ),
         ]
     )
 
 
-@patch(
-    'subprocess.check_output',
-    side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1),
-)
-def test_setup_subprocess_timeout(mock_subprocess):
-    homebrew_owner = 'Justintime50'
-    homebrew_tap = 'homebrew-formulas'
-    commit_email = 'user@example.com'
-    with pytest.raises(subprocess.TimeoutExpired):
-        Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)
-
-
-@patch(
-    'subprocess.check_output',
-    side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1),
-)
-def test_setup_process_error(mock_subprocess):
-    homebrew_owner = 'Justintime50'
-    homebrew_tap = 'homebrew-formulas'
-    commit_email = 'user@example.com'
-    with pytest.raises(subprocess.CalledProcessError):
-        Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)
-
-
 @patch('subprocess.check_output')
 def test_add(mock_subprocess):
+    """Tests that we call the correct git add command."""
     homebrew_tap = 'homebrew-formulas'
 
     Git.add(homebrew_tap)
     mock_subprocess.assert_called_once_with(
         ['git', '-C', homebrew_tap, 'add', '.'],
-        stdin=None,
+        stderr=-2,
+        text=True,
         timeout=TIMEOUT,
     )
 
 
-@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_add_subprocess_timeout(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-
-    with pytest.raises(subprocess.TimeoutExpired):
-        Git.add(homebrew_tap)
-
-
-@patch(
-    'subprocess.check_output', side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1)
-)
-def test_add_process_error(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-
-    with pytest.raises(subprocess.CalledProcessError):
-        Git.add(homebrew_tap)
-
-
 @patch('subprocess.check_output')
 def test_commit(mock_subprocess):
+    """Tests that we call the correct git commit command."""
     homebrew_tap = 'homebrew-formulas'
     repo_name = 'mock-repo'
     version = '0.1.0'
@@ -107,36 +72,16 @@ def test_commit(mock_subprocess):
     Git.commit(homebrew_tap, repo_name, version)
     mock_subprocess.assert_called_once_with(
         ['git', '-C', homebrew_tap, 'commit', '-m', f'"Brew formula update for {repo_name} version {version}"'],
-        stdin=None,
+        stderr=-2,
+        text=True,
         timeout=TIMEOUT,
     )
-
-
-@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_commit_subprocess_timeout(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-    repo_name = 'mock-repo'
-    version = '0.1.0'
-
-    with pytest.raises(subprocess.TimeoutExpired):
-        Git.commit(homebrew_tap, repo_name, version)
-
-
-@patch(
-    'subprocess.check_output', side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1)
-)
-def test_commit_process_error(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-    repo_name = 'mock-repo'
-    version = '0.1.0'
-
-    with pytest.raises(subprocess.CalledProcessError):
-        Git.commit(homebrew_tap, repo_name, version)
 
 
 @patch('homebrew_releaser.git.GITHUB_TOKEN', '123')
 @patch('subprocess.check_output')
 def test_push(mock_subprocess):
+    """Tests that we call the correct git push command."""
     homebrew_tap = 'homebrew-formulas'
     homebrew_owner = 'Justintime50'
 
@@ -150,26 +95,39 @@ def test_push(mock_subprocess):
             'push',
             f'https://x-access-token:123@github.com/{homebrew_owner}/{homebrew_tap}.git',
         ],
-        stdin=None,
+        stderr=-2,
+        text=True,
         timeout=TIMEOUT,
     )
 
 
-@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_push_subprocess_timeout(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-    homebrew_owner = 'Justintime50'
+@patch(
+    'subprocess.check_output',
+    side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1),
+)
+def test_setup_called_process_error(mock_subprocess):
+    """Tests that we log a subprocess error when they happen.
 
-    with pytest.raises(subprocess.TimeoutExpired):
-        Git.push(homebrew_tap, homebrew_owner)
+    All git commands should fail in the same manner.
+    """
+    homebrew_owner = 'Justintime50'
+    homebrew_tap = 'homebrew-formulas'
+    commit_email = 'user@example.com'
+    with pytest.raises(subprocess.CalledProcessError):
+        Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)
 
 
 @patch(
-    'subprocess.check_output', side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1)
+    'subprocess.check_output',
+    side_effect=Exception(),
 )
-def test_push_process_error(mock_subprocess):
-    homebrew_tap = 'homebrew-formulas'
-    homebrew_owner = 'Justintime50'
+def test_setup_exception(mock_subprocess):
+    """Tests that we log an exception when they happen.
 
-    with pytest.raises(subprocess.CalledProcessError):
-        Git.push(homebrew_tap, homebrew_owner)
+    All git commands should fail in the same manner.
+    """
+    homebrew_owner = 'Justintime50'
+    homebrew_tap = 'homebrew-formulas'
+    commit_email = 'user@example.com'
+    with pytest.raises(Exception):
+        Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -101,11 +101,12 @@ def test_push(mock_subprocess):
     )
 
 
+@patch('logging.Logger.debug')
 @patch(
     'subprocess.check_output',
     side_effect=subprocess.CalledProcessError(cmd='subprocess.check_output', returncode=1),
 )
-def test_setup_called_process_error(mock_subprocess):
+def test_setup_called_process_error(mock_subprocess, mock_logger):
     """Tests that we log a subprocess error when they happen.
 
     All git commands should fail in the same manner.
@@ -116,12 +117,15 @@ def test_setup_called_process_error(mock_subprocess):
     with pytest.raises(subprocess.CalledProcessError):
         Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)
 
+    mock_logger.assert_not_called()
 
+
+@patch('logging.Logger.debug')
 @patch(
     'subprocess.check_output',
     side_effect=Exception(),
 )
-def test_setup_exception(mock_subprocess):
+def test_setup_exception(mock_subprocess, mock_logger):
     """Tests that we log an exception when they happen.
 
     All git commands should fail in the same manner.
@@ -131,3 +135,5 @@ def test_setup_exception(mock_subprocess):
     commit_email = 'user@example.com'
     with pytest.raises(Exception):
         Git.setup(homebrew_owner, commit_email, homebrew_owner, homebrew_tap)
+
+    mock_logger.assert_not_called()

--- a/test/unit/test_readme_updater.py
+++ b/test/unit/test_readme_updater.py
@@ -183,6 +183,20 @@ def test_replace_table_contents():
         )
 
 
+@patch('logging.Logger.debug')
+@patch('homebrew_releaser.git.Git.add')
+def test_replace_table_contents_no_readme(mock_git_add, mock_logger):
+    """Tests that we do not run through the update readme block when there is no readme."""
+    ReadmeUpdater.replace_table_contents(
+        file_content='mock file contents',
+        old_table='old table contents',
+        new_table='new table contents',
+        homebrew_tap='./test',
+    )
+
+    mock_logger.assert_not_called()
+
+
 def test_does_readme_exist():
     """Tests that we can find a README in a directory."""
     readme = ReadmeUpdater.does_readme_exist('./')

--- a/test/unit/test_readme_updater.py
+++ b/test/unit/test_readme_updater.py
@@ -172,8 +172,7 @@ def test_read_current_readme():
     assert '# Homebrew Releaser' in readme
 
 
-@patch('homebrew_releaser.git.Git.add')
-def test_replace_table_contents(mock_git_add):
+def test_replace_table_contents():
     """Test that we add the new README changes to git."""
     with patch('builtins.open', mock_open()):
         ReadmeUpdater.replace_table_contents(
@@ -182,21 +181,6 @@ def test_replace_table_contents(mock_git_add):
             new_table='new table contents',
             homebrew_tap='./',
         )
-
-    mock_git_add.assert_called_once()
-
-
-@patch('homebrew_releaser.git.Git.add')
-def test_replace_table_contents_no_readme(mock_git_add):
-    """Tests that we do not `git add` for a README that doesn't exist."""
-    ReadmeUpdater.replace_table_contents(
-        file_content='mock file contents',
-        old_table='old table contents',
-        new_table='new table contents',
-        homebrew_tap='./test',
-    )
-
-    mock_git_add.assert_not_called()
 
 
 def test_does_readme_exist():


### PR DESCRIPTION
- Refactors git subprocess error handling
  - Sends `stderr` to `stdout` and captures the subprocess error output as text (previously got clobbered)
  - Returns stack trace
  - Use new helper function to keep all git calls uniform
  - More appropriate error logging and capture
  - Better tests surrounding subprocesses