### PR TITLE
fix: only remove leading 'v' from version

### DIFF
--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -73,7 +73,7 @@ class App:
         ).json()
         assets = latest_release['assets']
         version = latest_release['tag_name']
-        version_no_v = version.replace('v', '')
+        version_no_v = version.lstrip('v')
         logger.info(f'Latest release ({version}) successfully identified!')
 
         logger.info('Generating tar archive checksum(s)...')


### PR DESCRIPTION
While playing around with this action, I stumbled upon a weird issue where my pre-releases (versioned according to Python's [PEP440](https://peps.python.org/pep-0440/), e.g. `v0.1.0.dev0`) aren't picked up.
This PR changes the processing of the version string such that only _leading_ 'v' characters are removed (instead of replacing all 'v' characters in the version string).

PS.: Thanks for your awesome action!