### PR TITLE
fix: use REST API for downloading default release archives

### DIFF
--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -83,10 +83,10 @@ class App:
         archive_checksum_entries = ''
 
         # Auto-generated tar URL must come first for later use (order is important)
-        archive_base_url = f'https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}/archive/refs/tags/{version}'
-        auto_generated_release_tar = f'{archive_base_url}.tar.gz'
+        archive_base_url = f'{GITHUB_BASE_URL}/repos/{GITHUB_OWNER}/{GITHUB_REPO}'
+        auto_generated_release_tar = f'{archive_base_url}/tarball/{version}'
         archive_urls.append(auto_generated_release_tar)
-        auto_generated_release_zip = f'{archive_base_url}.zip'
+        auto_generated_release_zip = f'{archive_base_url}/zipball/{version}'
         archive_urls.append(auto_generated_release_zip)
 
         target_browser_download_base_url = (
@@ -117,6 +117,7 @@ class App:
                     or archive_url == auto_generated_release_zip
                     or archive_url == asset['browser_download_url']
                 ):
+
                     downloaded_filename = App.download_archive(download_url)
                     checksum = Checksum.get_checksum(downloaded_filename)
                     archive_filename = Utils.get_filename_from_path(archive_url)

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -18,7 +18,7 @@ class Utils:
 
         headers = GITHUB_HEADERS
         if stream:
-            headers['Accept'] = 'application/octet-stream'
+            headers['Accept'] += f',application/octet-stream'
 
         try:
             response = requests.get(

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -18,7 +18,7 @@ class Utils:
 
         headers = GITHUB_HEADERS
         if stream:
-            headers['Accept'] += f',application/octet-stream'
+            headers['Accept'] += ',application/octet-stream'
 
         try:
             response = requests.get(

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -24,7 +24,7 @@ class Utils:
             response = requests.get(
                 url,
                 headers=headers,
-                allow_redirects=True,
+                allow_redirects=True,  # We need to allow redirects to reach various GitHub resources
                 stream=stream,
                 timeout=TIMEOUT,
             )

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -24,6 +24,7 @@ class Utils:
             response = requests.get(
                 url,
                 headers=headers,
+                allow_redirects=True,
                 stream=stream,
                 timeout=TIMEOUT,
             )

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -15,7 +15,13 @@ def test_make_github_get_request(mock_request):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser'
     Utils.make_github_get_request(url=url)
 
-    mock_request.assert_called_once_with(url, headers=GITHUB_HEADERS, stream=False, timeout=30)
+    mock_request.assert_called_once_with(
+        url,
+        headers=GITHUB_HEADERS,
+        allow_redirects=True,
+        stream=False,
+        timeout=30,
+    )
 
 
 @patch('requests.get')
@@ -27,7 +33,13 @@ def test_make_github_get_request_stream(mock_request):
     headers = GITHUB_HEADERS
     headers['Accept'] = 'application/octet-stream'
 
-    mock_request.assert_called_once_with(url, headers=headers, stream=True, timeout=30)
+    mock_request.assert_called_once_with(
+        url,
+        headers=headers,
+        allow_redirects=True,
+        stream=True,
+        timeout=30,
+    )
 
 
 @patch('requests.get', side_effect=requests.exceptions.RequestException('mock-error'))


### PR DESCRIPTION
I initially described this issue here #41 but now have a better understanding of the issue which I submit for your approval. 

**Issue**

1. Attempting to use the default tarball/zip archives attached to a release do not work when accessing a private repo. This is not a token or permissions issue, `https://github.com/{GITHUB_OWNER}/{GITHUB_REPO}/archive/refs/tags/{version}` will not accept a PAT bearer token in the headers and returns a 404.

```sh
homebrew-releaser  | 2024-07-03 16:16:34,187 - INFO - Generating tar archive checksum(s)...
homebrew-releaser  | 404 Client Error: Not Found for url: https://github.com/repoowner/my-repo/archive/refs/tags/v1.0.1.tar.gz
```
2. Since this REST API endpoint returns a short-lived signed URL to download the file, the request must allow for the header `Accept: application/vnd.github+json` and follow the redirect. Since archives are always requested with the `stream=True` option, the code is currently overwriting that header value with `Accept: application/octet-stream` which works fine on the public URLs that link directly to a file. This causes a 415 response.

```sh
homebrew-releaser  | 2024-07-03 16:19:30,488 - INFO - Generating tar archive checksum(s)...
homebrew-releaser  | 415 Client Error: Unsupported Media Type for url: https://api.github.com/repos/repoowner/my-repo/tarball/v1.0.1
```

**Solution**

1. Update the auto-generated tar and zip URL to fetch these files from the REST API ([tar](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-tar) | [zip](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#download-a-repository-archive-zip)).

This works for both public repos and private repos (with proper read access in your PAT). From the GitHub docs:

> Gets a redirect URL to download a tar archive for a repository. If you omit :ref, the repository’s default branch (usually main) will be used. Please make sure your HTTP framework is configured to follow redirects or you will need to use the Location header to make a second GET request. Note: For private repositories, these links are temporary and expire after five minutes.

2. Since the `Accept` header allows for multiple comma-separated values to be present per the official [W3c spec](https://www.w3.org/Protocols/HTTP/HTRQ_Headers.html), the easiest solution is to send both MIME types when the stream option is enabled, `Accept: application/vnd.github+json, application/octet-stream` 

**QA**

- I have tested and confirmed the docker workflow successfully downloads and generated the formula for both private and public releases when all the architecture-specific targets are off. 

- I also copied and uploaded a properly named tar asset to a private repo and set `INPUT_TARGET_DARWIN_ARM64=true`. The asset URL was retrieved from the release metadata request instead of using the the auto-generated URLs and the formula was generated successfully. 

