### PR TITLE
fix: use different strategy for public vs private release archives

### DIFF
--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -1,6 +1,5 @@
-from typing import Optional
-
 import os
+from typing import Optional
 
 import woodchips
 

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -18,7 +18,7 @@ class Utils:
 
         headers = GITHUB_HEADERS
         if stream:
-            headers['Accept'] += ',application/octet-stream'
+            headers['Accept'] = 'application/octet-stream'
 
         try:
             response = requests.get(

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -217,9 +217,19 @@ def test_check_required_env_variables_missing_env_variable(mock_system_exit):
 
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
-def test_download_archive(mock_make_github_get_request, mock_write_file):
-    url = 'https://api.github.com/repos/Justintime50/homebrew-releaser/archive/v0.1.0.tar.gz'
-    App.download_archive(url)
+def test_download_public_archive(mock_make_github_get_request, mock_write_file):
+    url = 'https://github.com/repos/Justintime50/homebrew-releaser/archive/refs/tags/v0.1.0.tar.gz'
+    App.download_archive(url, True)
 
     mock_make_github_get_request.assert_called_once_with(url=url, stream=True)
+    mock_write_file.assert_called_once()  # TODO: Assert `called_with` here instead
+
+
+@patch('homebrew_releaser.utils.Utils.write_file')
+@patch('homebrew_releaser.utils.Utils.make_github_get_request')
+def test_download_private_archive(mock_make_github_get_request, mock_write_file):
+    url = 'https://api.github.com/repos/Justintime50/homebrew-releaser/tarball/v0.1.0'
+    App.download_archive(url, False)
+
+    mock_make_github_get_request.assert_called_once_with(url=url, stream=False)
     mock_write_file.assert_called_once()  # TODO: Assert `called_with` here instead


### PR DESCRIPTION
Fix regression issues from release v0.18.2 which I raised in issue #43. 

The issue with private repos + auto-generated tar/zip archives switched those to a REST API endpoint for downloading the archive. To accommodate this, the `make_github_get_request` method was updated to change the HTTP headers, to allow both JSON and raw streaming binary. This appears to work fine, except that in some combinations, the checksum is actually for the JSON response of fetching the file and not the file itself. The result is that the Brew formula appears to be generated successfully, but since the checksum does not match, the formula will not install. 

And while outside the scope of this repo, due to the swap of retrieving auto-generated archive URLs for public repos, it means the structure of that URL changed and could break existing Homebrew Formula custom download strategies that perform a regex match against the download URL.

**Solution**

Walk back the changes to fix only the private repo + auto-generated archive downloads, while leaving the other strategies unchanged. 

To do this:

1. Check if the repository is private and then conditionally generate different auto-generated URLs.
2. Revert the previous behavior of extending the accepted content-type headers so that is back to either looking for JSON or streaming binary. Instead allow for sending the `stream` argument to `download_archive` so that it can remain `True` for the previous calls that use *github.com* browser_urls and `False` for *api.github.com* calls.