### PR TITLE
fix: prevent mutation of GITHUB_HEADERS

### DIFF
--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -49,7 +49,7 @@ class Checksum:
             checksum_file_content = filename.read()
 
         upload_url = f'https://uploads.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/{latest_release_id}/assets?name={CHECKSUM_FILE}'  # noqa
-        headers = GITHUB_HEADERS
+        headers = GITHUB_HEADERS.copy()
         headers['Content-Type'] = 'text/plain'
 
         try:

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -16,7 +16,7 @@ class Utils:
         """Make an HTTP GET request."""
         logger = woodchips.get(LOGGER_NAME)
 
-        headers = GITHUB_HEADERS
+        headers = GITHUB_HEADERS.copy()
         if stream:
             headers['Accept'] = 'application/octet-stream'
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -30,7 +30,7 @@ def test_make_github_get_request_stream(mock_request):
     url = 'https://api.github.com/repos/Justintime50/homebrew-releaser'
     Utils.make_github_get_request(url=url, stream=True)
 
-    headers = GITHUB_HEADERS
+    headers = GITHUB_HEADERS.copy()
     headers['Accept'] = 'application/octet-stream'
 
     mock_request.assert_called_once_with(


### PR DESCRIPTION
I was getting the following error when publishing a formula:
```
415 Client Error: Unsupported Media Type for url: https://uploads.github.com/repos/USER/REPO/releases/RELEASE_ID/assets?name=checksum.txt
```

Digging into it, the `GITHUB_HEADERS` constant was getting modified with the wrong `Accept` header during an earlier call, so that the `uploads` API was receiving `application/octet-stream` instead of `application/vnd.github.v3+json`.

Adding `.copy()` to every use of `GITHUB_HEADERS` ensures that the original constant is not modified. A future refactor could use a different, immutable type for the constant, but `.copy()` fixes the issue for now.