### PR TITLE
fix: docker references and test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,8 @@ jobs:
       - name: Build and run Docker image
         run: |
           docker build . -t justintime50/homebrew-releaser
-          docker run -e INPUT_SKIP_COMMIT=true \
+          docker run --workdir /github/workspace \
+            -e INPUT_SKIP_COMMIT=true \
             -e INPUT_DEBUG=true \
             -e GITHUB_REPOSITORY=justintime50/homebrew-releaser \
             -e INPUT_HOMEBREW_OWNER=justintime50 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             -e INPUT_HOMEBREW_TAP=homebrew-formulas \
             -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e INPUT_INSTALL=virtualenv_install_with_resources \
-            -e INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv \
+            -e INPUT_FORMULA_INCLUDES="include Language::Python::Virtualenv" \
             -e INPUT_UPDATE_PYTHOHN_RESOURCES=true \
             --rm justintime50/homebrew-releaser
   coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '.github/workflows/build.yml'
+      - 'Dockerfile'
       - '**/*.py'
     branches:
       - '**'
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build.yml'
+      - 'Dockerfile'
       - '**/*.py'
   workflow_dispatch: ~
 
@@ -49,11 +51,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-      - name: Build Docker image
-        run: docker build . -t justintime50/homebrew-releaser
+      - name: Build and run Docker image
+        run: |
+          docker build . -t justintime50/homebrew-releaser
+          docker run -e INPUT_SKIP_COMMIT=true \
+            -e INPUT_DEBUG=true \
+            -e GITHUB_REPOSITORY=justintime50/homebrew-releaser \
+            -e INPUT_HOMEBREW_OWNER=justintime50 \
+            -e INPUT_HOMEBREW_TAP=homebrew-formulas \
+            -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e "INPUT_INSTALL=install-instructions-here" \
+            --rm justintime50/homebrew-releaser
   coverage:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
             -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e INPUT_INSTALL=virtualenv_install_with_resources \
             -e INPUT_FORMULA_INCLUDES="include Language::Python::Virtualenv" \
-            -e INPUT_UPDATE_PYTHOHN_RESOURCES=true \
+            -e INPUT_UPDATE_PYTHON_RESOURCES=true \
             --rm justintime50/homebrew-releaser
   coverage:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,9 @@ jobs:
             -e INPUT_HOMEBREW_OWNER=justintime50 \
             -e INPUT_HOMEBREW_TAP=homebrew-formulas \
             -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e "INPUT_INSTALL=virtualenv_install_with_resources" \
-            -e "INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv" \
-            -e "INPUT_UPDATE_PYTHOHN_RESOURCES=true" \
+            -e INPUT_INSTALL=virtualenv_install_with_resources \
+            -e INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv \
+            -e INPUT_UPDATE_PYTHOHN_RESOURCES=true \
             --rm justintime50/homebrew-releaser
   coverage:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             -e INPUT_HOMEBREW_TAP=homebrew-formulas \
             -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e "INPUT_INSTALL=virtualenv_install_with_resources" \
-            -e "INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv"
+            -e "INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv" \
             -e "INPUT_UPDATE_PYTHOHN_RESOURCES=true" \
             --rm justintime50/homebrew-releaser
   coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
             -e INPUT_HOMEBREW_OWNER=justintime50 \
             -e INPUT_HOMEBREW_TAP=homebrew-formulas \
             -e INPUT_GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            -e "INPUT_INSTALL=install-instructions-here" \
+            -e "INPUT_INSTALL=virtualenv_install_with_resources" \
+            -e "INPUT_FORMULA_INCLUDES=include Language::Python::Virtualenv"
+            -e "INPUT_UPDATE_PYTHOHN_RESOURCES=true" \
             --rm justintime50/homebrew-releaser
   coverage:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
             -e INPUT_INSTALL=virtualenv_install_with_resources \
             -e INPUT_FORMULA_INCLUDES="include Language::Python::Virtualenv" \
             -e INPUT_UPDATE_PYTHON_RESOURCES=true \
-            --rm justintime50/homebrew-releaser
+            justintime50/homebrew-releaser
   coverage:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## v2.1.1 (2025-06-13)
 
-- Fixes Dockerfile references so Python/Git can access what it needs
+- Rolls back the Dockerfile changes and more correctly installs Brew into the existing image we had
+- Drop `shasum` dependency and calculate checksums from inside Python
 
 ## v2.1.0 (2025-06-10)
+
+> DO NOT use this image as it cannot build properly.
 
 - Changes Docker image from `python3.13` to `brew` allowing us to use all brew tools during builds
 - Adds `update_python_resources` so Python formula can update their required resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Rolls back the Dockerfile changes and more correctly installs Brew into the existing image we had
 - Drop `shasum` dependency and calculate checksums from inside Python
+- Bumps `TIMEOUT` from 60 to 300 seconds for larger projects (downloading Python packages can take some time)
 
 ## v2.1.0 (2025-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # CHANGELOG
 
-## v2.1.1 (2025-06-13)
+## v2.1.1 (2025-06-14)
 
-- Rolls back the Dockerfile changes and more correctly installs Brew into the existing image we had
+- Corrects Python references in Dockerfile
+- Uses `/tmp` as working directory due to permissioning issues
 - Drop `shasum` dependency and calculate checksums from inside Python
 - Bumps `TIMEOUT` from 60 to 300 seconds for larger projects (downloading Python packages can take some time)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    # Needed for `shasum`
+    perl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,10 @@
-FROM python:3.13-slim
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    git
-
-RUN useradd -m -s /bin/bash linuxbrew
-USER linuxbrew
-WORKDIR /home/linuxbrew
-
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
-
-RUN mkdir -p /home/linuxbrew/app
-
-WORKDIR /home/linuxbrew/app
+FROM homebrew/brew:4.5.6
 
 COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
 COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
-RUN pip install .
+RUN brew install python@3.13 \
+    && python3 -m venv venv \
+    && venv/bin/pip install .
 
-ENTRYPOINT ["python", "/home/linuxbrew/app/homebrew_releaser/app.py"]
+ENTRYPOINT [ "venv/bin/python3", "homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM homebrew/brew:4.5.6
 
-COPY homebrew_releaser /tmp/homebrew_releaser
-COPY setup.py /tmp/setup.py
+COPY homebrew_releaser /tmp/homebrew-releaser/homebrew_releaser
+COPY setup.py /tmp/homebrew-releaser/setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv /tmp/venv \
-    && /tmp/venv/bin/pip install .
+    && python3 -m venv /tmp/homebrew-releaser/venv \
+    && /tmp/homebrew-releaser/venv/bin/pip install .
 
-ENTRYPOINT [ "/tmp/venv/bin/python3", "/tmp/homebrew_releaser/app.py" ]
+ENTRYPOINT ["/bin/bash", "-c", "cd /tmp && exec /tmp/homebrew-releaser/venv/bin/python3 /tmp/homebrew-releaser/homebrew_releaser/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.13-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends git
 
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
-    && echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /etc/profile \
-    && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
     
 COPY homebrew_releaser homebrew_releaser
 COPY setup.py setup.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,4 @@ ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}
 COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
 COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
-RUN pip install .
-
-ENTRYPOINT [ "python", "/home/linuxbrew/homebrew_releaser/app.py" ]
+ENTRYPOINT ["/bin/bash", "-c", "pip install . && python /home/linuxbrew/homebrew_releaser/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
 COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv venv \
-    && venv/bin/pip install .
+    && python3 -m venv /home/linuxbrew/venv \
+    && /home/linuxbrew/venv/bin/pip install .
 
-ENTRYPOINT [ "venv/bin/python3", "homebrew_releaser/app.py" ]
+ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN brew install python@3.13 \
     && python3 -m venv /home/linuxbrew/venv \
     && /home/linuxbrew/venv/bin/pip install .
 
+WORKDIR /tmp/homebrew-releaser
+
 ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM homebrew/brew:4.5.6
 
-WORKDIR /github/workspace
-
 COPY homebrew_releaser homebrew_releaser
 COPY setup.py setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv venv \
-    && venv/bin/pip install .
+    && python3 -m venv /home/linuxbrew/venv \
+    && /home/linuxbrew/venv/bin/pip install . \
+    && chown -R linuxbrew:linuxbrew /home/linuxbrew
 
-ENTRYPOINT [ "venv/bin/python3", "homebrew_releaser/app.py" ]
+ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
 RUN pip install .
 
-ENTRYPOINT [ "python", "homebrew_releaser/app.py" ]
+ENTRYPOINT [ "python", "/home/linuxbrew/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git
 
+RUN useradd -m -s /bin/bash linuxbrew
+USER linuxbrew
+WORKDIR /home/linuxbrew
+
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
-    
-COPY homebrew_releaser homebrew_releaser
-COPY setup.py setup.py
+
+COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
+COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
 RUN pip install .
 
-ENTRYPOINT [ "python", "/homebrew_releaser/app.py" ]
+ENTRYPOINT [ "python", "homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,13 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
+RUN mkdir -p /home/linuxbrew/app
+
+WORKDIR /home/linuxbrew/app
+
 COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
 COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
-ENTRYPOINT ["/bin/bash", "-c", "pip install . && python /home/linuxbrew/homebrew_releaser/app.py"]
+RUN pip install .
+
+ENTRYPOINT ["python", "/home/linuxbrew/app/homebrew_releaser/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM homebrew/brew:4.5.6
 
-COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
-COPY --chown=linuxbrew:linuxbrew setup.py setup.py
+COPY homebrew_releaser /tmp/homebrew_releaser
+COPY setup.py /tmp/setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv /home/linuxbrew/venv \
-    && /home/linuxbrew/venv/bin/pip install .
+    && python3 -m venv /tmp/venv \
+    && /tmp/venv/bin/pip install .
 
-WORKDIR /tmp/homebrew-releaser
-
-ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]
+ENTRYPOINT [ "/tmp/venv/bin/python3", "/tmp/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    # Needed for `shasum`
-    perl \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git
 
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
     && echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /etc/profile \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git
 
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM homebrew/brew:4.5.6
 
-COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
-COPY --chown=linuxbrew:linuxbrew setup.py setup.py
+WORKDIR /github/workspace
+
+COPY homebrew_releaser homebrew_releaser
+COPY setup.py setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv /home/linuxbrew/venv \
-    && /home/linuxbrew/venv/bin/pip install .
+    && python3 -m venv venv \
+    && venv/bin/pip install .
 
-ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]
+ENTRYPOINT [ "venv/bin/python3", "homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM homebrew/brew:4.5.6
+FROM python:3.13-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+    && echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /etc/profile \
+    && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+    
 COPY homebrew_releaser homebrew_releaser
 COPY setup.py setup.py
 
-RUN brew install python@3.13 \
-    && python3 -m venv /home/linuxbrew/venv \
-    && /home/linuxbrew/venv/bin/pip install . \
-    && chown -R linuxbrew:linuxbrew /home/linuxbrew
+RUN pip install .
 
-ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]
+ENTRYPOINT [ "python", "/homebrew_releaser/app.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM homebrew/brew:4.5.6
 
-COPY homebrew_releaser /tmp/homebrew-releaser/homebrew_releaser
-COPY setup.py /tmp/homebrew-releaser/setup.py
+COPY --chown=linuxbrew:linuxbrew homebrew_releaser homebrew_releaser
+COPY --chown=linuxbrew:linuxbrew setup.py setup.py
 
 RUN brew install python@3.13 \
-    && python3 -m venv /tmp/homebrew-releaser/venv \
-    && /tmp/homebrew-releaser/venv/bin/pip install .
+    && python3 -m venv /home/linuxbrew/venv \
+    && /home/linuxbrew/venv/bin/pip install .
 
-ENTRYPOINT ["/bin/bash", "-c", "cd /tmp && exec /tmp/homebrew-releaser/venv/bin/python3 /tmp/homebrew-releaser/homebrew_releaser/app.py"]
+ENTRYPOINT [ "/home/linuxbrew/venv/bin/python3", "/home/linuxbrew/homebrew_releaser/app.py" ]

--- a/README.md
+++ b/README.md
@@ -144,12 +144,45 @@ jobs:
           debug: false
 ```
 
+#### Python
+
+To release a Python package using Homebrew Releaser, one may setup their workflow like so:
+
+```yml
+on:
+  push:
+
+jobs:
+  homebrew-releaser:
+    runs-on: ubuntu-latest
+    name: homebrew-releaser
+    steps:
+      - name: Release my project to my Homebrew tap
+        uses: Justintime50/homebrew-releaser@v2
+        with:
+          homebrew_owner: Justintime50
+          homebrew_tap: homebrew-formulas
+          github_token: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          commit_owner: homebrew-releaser
+          commit_email: homebrew-releaser@example.com
+
+          # Python specific variables
+          depends_on: 'python@3.y'
+          install: 'virtualenv_install_with_resources'
+          formula_includes: 'include Language::Python::Virtualenv'
+          update_python_resources: true
+```
+
 ## Development
 
 ```sh
 # Get a comprehensive list of development tools
 just --list
 ```
+
+### Docker & GitHub Actions Setup
+
+We have to play a balancing game of using Homebrew (cannot be root) and writing various files to use Homebrew Releaser (must be root or have write access), to get around this we setup and install everything using a `linuxbrew` user and directory but then everything afterwards (git clone, writing files, etc) occur inside of `/tmp`. This is an unfortunate but required path to take since using the official Python Docker image won't let us use Brew and have write access while using the Brew image gets us Homebrew but we cannot write in the normal directory. Thus we hack it a bit and just play inside of `/tmp`.
 
 ### Run Manually via Docker
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ jobs:
 
           # Run 'brew update-python-resources' on the formula to add Python resources.
           # Docs: https://docs.brew.sh/Python-for-Formula-Authors#python-declarations-for-applications
+          # NOTE: This only works with public repositories currently and must be done manually if for a private repo.
           # Default is shown - boolean
           update_python_resources: false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   homebrew-releaser:
     container_name: homebrew-releaser
     build: .
+    # Mimicks the GitHub Actions environment
+    working_dir: /github/workspace
     environment:
       # Env vars that should be `false` should be left empty
       - GITHUB_REPOSITORY=username/repo

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -170,6 +170,9 @@ class App:
         Utils.write_file(formula_filepath, template, 'w')
 
         if UPDATE_PYTHON_RESOURCES:
+            import time
+
+            time.sleep(1000)
             logger.info('Attempting to update Python resources in the formula...')
             Formula.update_python_resources(formula_dir, formula_filename)
             if DEBUG:

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -170,9 +170,6 @@ class App:
         Utils.write_file(formula_filepath, template, 'w')
 
         if UPDATE_PYTHON_RESOURCES:
-            import time
-
-            time.sleep(1000)
             logger.info('Attempting to update Python resources in the formula...')
             Formula.update_python_resources(formula_dir, formula_filename)
             if DEBUG:

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -165,7 +165,7 @@ class App:
         )
 
         formula_filename = f'{repository["name"]}.rb'
-        formula_dir = os.path.join('/tmp', 'homebrew-releaser', HOMEBREW_TAP, FORMULA_FOLDER)
+        formula_dir = os.path.join(HOMEBREW_TAP, FORMULA_FOLDER)
         formula_filepath = os.path.join(formula_dir, formula_filename)
         Utils.write_file(formula_filepath, template, 'w')
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -131,7 +131,7 @@ class App:
                     # For REST API requests, we should not stream archive file, but it is fine for browser URLs
                     stream = False if archive_url.find("api.github.com") != -1 else True
                     downloaded_filename = App.download_archive(download_url, stream)
-                    checksum = Checksum.get_checksum(downloaded_filename)
+                    checksum = Checksum.calculate_checksum(downloaded_filename)
                     archive_filename = Utils.get_filename_from_path(archive_url)
                     archive_checksum_entries += f'{checksum} {archive_filename}\n'
                     checksums.append(
@@ -185,7 +185,7 @@ class App:
         else:
             logger.debug('Skipping update to project README.')
 
-        # Although users can skip a commit, still commit (and don't push) to dry-run a commit
+        # Although users can skip a commit, still commit (but don't push) to dry-run the commit for debugging purposes
         Git.add(HOMEBREW_TAP)
         Git.commit(HOMEBREW_TAP, GITHUB_REPO, version)
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -165,7 +165,7 @@ class App:
         )
 
         formula_filename = f'{repository["name"]}.rb'
-        formula_dir = os.path.join(HOMEBREW_TAP, FORMULA_FOLDER)
+        formula_dir = os.path.join('/tmp', 'homebrew-releaser', HOMEBREW_TAP, FORMULA_FOLDER)
         formula_filepath = os.path.join(formula_dir, formula_filename)
         Utils.write_file(formula_filepath, template, 'w')
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -165,7 +165,7 @@ class App:
         )
 
         formula_filename = f'{repository["name"]}.rb'
-        formula_dir = os.path.join(HOMEBREW_TAP, FORMULA_FOLDER)
+        formula_dir = Utils.get_working_dir(os.path.join(HOMEBREW_TAP, FORMULA_FOLDER))
         formula_filepath = os.path.join(formula_dir, formula_filename)
         Utils.write_file(formula_filepath, template, 'w')
 

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -1,4 +1,4 @@
-import subprocess  # nosec
+import hashlib
 from typing import Any
 
 import requests
@@ -21,19 +21,10 @@ class Checksum:
         logger = woodchips.get(LOGGER_NAME)
 
         try:
-            command = ['shasum', '-a', '256', tar_filepath]
-            output = subprocess.check_output(  # nosec
-                command,
-                stdin=None,
-                stderr=None,
-                timeout=TIMEOUT,
-            )
-            checksum = output.decode().split()[0]
-            checksum_filename = output.decode().split()[1]
-            logger.debug(f'Checksum for {checksum_filename} generated successfully: {checksum}')
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(error)
-        except subprocess.CalledProcessError as error:
+            with open(tar_filepath, "rb") as content:
+                checksum = hashlib.sha256(content.read()).hexdigest()
+            logger.debug(f'Checksum for {tar_filepath} generated successfully: {checksum}')
+        except Exception as error:
             raise SystemExit(error)
 
         return checksum

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -17,7 +17,7 @@ from homebrew_releaser.utils import Utils
 
 class Checksum:
     @staticmethod
-    def get_checksum(tar_filepath: str) -> str:
+    def calculate_checksum(tar_filepath: str) -> str:
         """Gets the checksum of a file."""
         logger = woodchips.get(LOGGER_NAME)
 

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -12,6 +12,7 @@ from homebrew_releaser.constants import (
     LOGGER_NAME,
     TIMEOUT,
 )
+from homebrew_releaser.utils import Utils
 
 
 class Checksum:
@@ -21,7 +22,7 @@ class Checksum:
         logger = woodchips.get(LOGGER_NAME)
 
         try:
-            with open(tar_filepath, "rb") as content:
+            with open(Utils.get_working_dir(tar_filepath), "rb") as content:
                 checksum = hashlib.sha256(content.read()).hexdigest()
             logger.debug(f'Checksum for {tar_filepath} generated successfully: {checksum}')
         except Exception as error:
@@ -36,7 +37,7 @@ class Checksum:
 
         latest_release_id = latest_release['id']
 
-        with open(CHECKSUM_FILE, 'rb') as filename:
+        with open(Utils.get_working_dir(CHECKSUM_FILE), 'rb') as filename:
             checksum_file_content = filename.read()
 
         upload_url = f'https://uploads.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/{latest_release_id}/assets?name={CHECKSUM_FILE}'  # noqa

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -27,6 +27,7 @@ GITHUB_HEADERS = {
     'Authorization': f'Bearer {GITHUB_TOKEN}',
 }
 CHECKSUM_FILE = 'checksum.txt'
+WORKING_DIR = '/tmp/homebrew-releaser'
 
 # Formula Constants
 ARTICLES = {

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -27,7 +27,7 @@ GITHUB_HEADERS = {
     'Authorization': f'Bearer {GITHUB_TOKEN}',
 }
 CHECKSUM_FILE = 'checksum.txt'
-WORKING_DIR = '/tmp/homebrew-releaser'
+WORKING_DIR = '/tmp/homebrew-releaser'  # nosec
 
 # Formula Constants
 ARTICLES = {

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -20,7 +20,7 @@ VERSION = os.getenv('INPUT_VERSION')
 
 # App Constants
 LOGGER_NAME = 'homebrew-releaser'
-TIMEOUT = 60
+TIMEOUT = 300
 GITHUB_HEADERS = {
     'Accept': 'application/vnd.github.v3+json',
     'Agent': 'Homebrew Releaser',

--- a/homebrew_releaser/formula.py
+++ b/homebrew_releaser/formula.py
@@ -282,7 +282,6 @@ end
             raise SystemExit("brew not found in PATH")
 
         try:
-            logger.info(f'Running brew update-python-resources for {formula_filename}...')
             subprocess.check_output(
                 f'cd {formula_dir} && {brew_path} update-python-resources {formula_filename}',
                 stderr=subprocess.STDOUT,
@@ -290,10 +289,10 @@ end
                 timeout=TIMEOUT,
                 shell=True,  # nosec
             )
-            logger.info(f'Successfully updated Python resources for {formula_filename}')
-        except subprocess.TimeoutExpired as e:
-            raise SystemExit from e
+            logger.info('Updated Python resources successfully.')
+        except subprocess.TimeoutExpired:
+            raise SystemExit('Timed out updating Python resources')
         except subprocess.CalledProcessError as e:
             error_output = e.output if hasattr(e, "output") else ""
 
-            raise SystemExit(f"An error occurred while updating Python resources: {e}\nOutput:\n{error_output}") from e
+            raise SystemExit(f"An error occurred while updating Python resources: {error_output}")

--- a/homebrew_releaser/formula.py
+++ b/homebrew_releaser/formula.py
@@ -294,4 +294,6 @@ end
         except subprocess.TimeoutExpired as e:
             raise SystemExit from e
         except subprocess.CalledProcessError as e:
-            raise SystemExit(f'An error occurred while updating Python resources: {e}') from e
+            error_output = e.output if hasattr(e, "output") else ""
+
+            raise SystemExit(f"An error occurred while updating Python resources: {e}\nOutput:\n{error_output}") from e

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -23,6 +23,7 @@ class Git:
         logger = woodchips.get(LOGGER_NAME)
 
         import os
+        print(os.getenv('GITHUB_WORKSPACE'))
         print("User:", os.getuid(), os.getgid())
         subprocess.run(["ls", "-ld", "."], check=True)
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -8,6 +8,7 @@ from homebrew_releaser.constants import (
     LOGGER_NAME,
     TIMEOUT,
 )
+from homebrew_releaser.utils import Utils
 
 
 class Git:
@@ -28,10 +29,10 @@ class Git:
                 'clone',
                 '--depth=1',
                 f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git',
-                homebrew_tap,
+                Utils.get_working_dir(homebrew_tap),
             ],
-            ['git', '-C', homebrew_tap, 'config', 'user.name', f'"{commit_owner}"'],
-            ['git', '-C', homebrew_tap, 'config', 'user.email', commit_email],
+            ['git', '-C', Utils.get_working_dir(homebrew_tap), 'config', 'user.name', f'"{commit_owner}"'],
+            ['git', '-C', Utils.get_working_dir(homebrew_tap), 'config', 'user.email', commit_email],
         ]
 
         for command in commands:
@@ -42,14 +43,14 @@ class Git:
     @staticmethod
     def add(homebrew_tap: str):
         """Adds assets to a git commit."""
-        command = ['git', '-C', homebrew_tap, 'add', '.']
+        command = ['git', '-C', Utils.get_working_dir(homebrew_tap), 'add', '.']
         Git._run_git_subprocess(command, 'Assets added to git commit successfully.')
 
     @staticmethod
     def commit(homebrew_tap: str, repo_name: str, version: str):
         """Commits assets to the Homebrew tap (repo)."""
         # fmt: off
-        command = ['git', '-C', homebrew_tap, 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
+        command = ['git', '-C', Utils.get_working_dir(homebrew_tap), 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
         # fmt: on
         Git._run_git_subprocess(command, 'Assets committed successfully.')
 
@@ -57,7 +58,7 @@ class Git:
     def push(homebrew_tap: str, homebrew_owner: str):
         """Pushes assets to the remote Homebrew tap (repo)."""
         # fmt: off
-        command = ['git', '-C', homebrew_tap, 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
+        command = ['git', '-C', Utils.get_working_dir(homebrew_tap), 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
         # fmt: on
         Git._run_git_subprocess(command, f'Assets pushed successfully to {homebrew_tap}.')
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -22,11 +22,6 @@ class Git:
         """
         logger = woodchips.get(LOGGER_NAME)
 
-        import os
-        print(os.getenv('GITHUB_WORKSPACE'))
-        print("User:", os.getuid(), os.getgid())
-        subprocess.run(["ls", "-ld", "."], check=True)
-
         commands = [
             [
                 'git',

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -22,6 +22,10 @@ class Git:
         """
         logger = woodchips.get(LOGGER_NAME)
 
+        import os
+        print("User:", os.getuid(), os.getgid())
+        subprocess.run(["ls", "-ld", "."], check=True)
+
         commands = [
             [
                 'git',

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -1,4 +1,3 @@
-import os
 import subprocess  # nosec
 from typing import Optional
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -23,18 +23,16 @@ class Git:
         """
         logger = woodchips.get(LOGGER_NAME)
 
-        homebrew_tap_path = Git._get_homebrew_tap_path(homebrew_tap)
-
         commands = [
             [
                 'git',
                 'clone',
                 '--depth=1',
                 f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git',
-                homebrew_tap_path,
+                homebrew_tap,
             ],
-            ['git', '-C', homebrew_tap_path, 'config', 'user.name', f'"{commit_owner}"'],
-            ['git', '-C', homebrew_tap_path, 'config', 'user.email', commit_email],
+            ['git', '-C', homebrew_tap, 'config', 'user.name', f'"{commit_owner}"'],
+            ['git', '-C', homebrew_tap, 'config', 'user.email', commit_email],
         ]
 
         for command in commands:
@@ -45,25 +43,22 @@ class Git:
     @staticmethod
     def add(homebrew_tap: str):
         """Adds assets to a git commit."""
-        homebrew_tap_path = Git._get_homebrew_tap_path(homebrew_tap)
-        command = ['git', '-C', homebrew_tap_path, 'add', '.']
+        command = ['git', '-C', homebrew_tap, 'add', '.']
         Git._run_git_subprocess(command, 'Assets added to git commit successfully.')
 
     @staticmethod
     def commit(homebrew_tap: str, repo_name: str, version: str):
         """Commits assets to the Homebrew tap (repo)."""
-        homebrew_tap_path = Git._get_homebrew_tap_path(homebrew_tap)
         # fmt: off
-        command = ['git', '-C', homebrew_tap_path, 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
+        command = ['git', '-C', homebrew_tap, 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
         # fmt: on
         Git._run_git_subprocess(command, 'Assets committed successfully.')
 
     @staticmethod
     def push(homebrew_tap: str, homebrew_owner: str):
         """Pushes assets to the remote Homebrew tap (repo)."""
-        homebrew_tap_path = Git._get_homebrew_tap_path(homebrew_tap)
         # fmt: off
-        command = ['git', '-C', homebrew_tap_path, 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
+        command = ['git', '-C', homebrew_tap, 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
         # fmt: on
         Git._run_git_subprocess(command, f'Assets pushed successfully to {homebrew_tap}.')
 
@@ -87,9 +82,3 @@ class Git:
         except Exception as error:
             logger.critical(error)
             raise
-
-    @staticmethod
-    def _get_homebrew_tap_path(homebrew_tap: str) -> str:
-        """Returns the path to the Homebrew tap."""
-        os.makedirs('/tmp/homebrew-releaser', exist_ok=True)
-        return os.path.join('/tmp', 'homebrew-releaser', homebrew_tap)

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -50,7 +50,7 @@ class ReadmeUpdater:
 
         try:
             for filename in sorted(files):
-                with open(Utils.get_working_dir(os.path.join(homebrew_tap_path, filename)), 'r') as formula:
+                with open(os.path.join(homebrew_tap_path, filename), 'r') as formula:
                     # Set empty defaults
                     final_name = ''
                     final_desc = ''

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -13,6 +13,7 @@ from homebrew_releaser.constants import (
     FORMULA_FOLDER,
     LOGGER_NAME,
 )
+from homebrew_releaser.utils import Utils
 
 
 TABLE_START_TAG = '<!-- project_table_start -->'
@@ -40,7 +41,7 @@ class ReadmeUpdater:
         """Retrieve the name, description, and homepage from each
         Ruby formula file in the homebrew tap repo.
         """
-        homebrew_tap_path = os.path.join(homebrew_tap, FORMULA_FOLDER)
+        homebrew_tap_path = Utils.get_working_dir(os.path.join(homebrew_tap, FORMULA_FOLDER))
         formulas = []
         files = os.listdir(homebrew_tap_path)
 
@@ -49,7 +50,7 @@ class ReadmeUpdater:
 
         try:
             for filename in sorted(files):
-                with open(os.path.join(homebrew_tap_path, filename), 'r') as formula:
+                with open(Utils.get_working_dir(os.path.join(homebrew_tap_path, filename)), 'r') as formula:
                     # Set empty defaults
                     final_name = ''
                     final_desc = ''
@@ -124,7 +125,7 @@ class ReadmeUpdater:
         old_table = ''
 
         if readme:
-            with open(readme, 'r') as readme_contents:
+            with open(Utils.get_working_dir(readme), 'r') as readme_contents:
                 for line in readme_contents:
                     normalized_line = line.strip().lower()
                     if normalized_line == TABLE_START_TAG:
@@ -158,7 +159,7 @@ class ReadmeUpdater:
         file_content = ""
 
         if readme:
-            with open(readme, 'r') as readme_contents:
+            with open(Utils.get_working_dir(readme), 'r') as readme_contents:
                 file_content = readme_contents.read()
             logger.debug(f'{readme} read successfully.')
 
@@ -174,7 +175,7 @@ class ReadmeUpdater:
         readme = ReadmeUpdater.does_readme_exist(homebrew_tap)
 
         if readme:
-            with open(readme, 'w') as readme_contents:
+            with open(Utils.get_working_dir(readme), 'w') as readme_contents:
                 readme_contents.write(file_content.replace(old_table, new_table))
             logger.debug(f'{readme} table updated successfully.')
 
@@ -191,7 +192,7 @@ class ReadmeUpdater:
 
         for filename in files:
             if filename.lower() == readme_filename:
-                readme_to_open = os.path.join(homebrew_tap, filename)
+                readme_to_open = Utils.get_working_dir(os.path.join(homebrew_tap, filename))
                 break
 
         return readme_to_open

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import requests
@@ -7,6 +8,7 @@ from homebrew_releaser.constants import (
     GITHUB_HEADERS,
     LOGGER_NAME,
     TIMEOUT,
+    WORKING_DIR,
 )
 
 
@@ -41,7 +43,7 @@ class Utils:
         logger = woodchips.get(LOGGER_NAME)
 
         try:
-            with open(file_path, mode) as f:
+            with open(Utils.get_working_dir(file_path), mode) as f:
                 f.write(content)
             logger.debug(f'{file_path} written successfully.')
         except Exception as error:
@@ -51,3 +53,8 @@ class Utils:
     def get_filename_from_path(path: str) -> str:
         """Gets the last part of a path (the filename)."""
         return path.rsplit('/', 1)[1]
+
+    @staticmethod
+    def get_working_dir(additional_path: str) -> str:
+        """Gets the working directory."""
+        return os.path.join(WORKING_DIR, additional_path)

--- a/test/unit/test_app.py
+++ b/test/unit/test_app.py
@@ -14,7 +14,7 @@ from homebrew_releaser.app import App
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -22,7 +22,7 @@ def test_run_github_action_skip_commit(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,
@@ -38,7 +38,7 @@ def test_run_github_action_skip_commit(
     mock_check_env_variables.assert_called_once()
     assert mock_make_github_get_request.call_count == 2
     mock_download_archive.call_count == 2
-    mock_get_checksum.call_count == 2
+    mock_calculate_checksum.call_count == 2
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
@@ -56,7 +56,7 @@ def test_run_github_action_skip_commit(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -64,7 +64,7 @@ def test_run_github_action(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,
@@ -81,7 +81,7 @@ def test_run_github_action(
     mock_check_env_variables.assert_called_once()
     assert mock_make_github_get_request.call_count == 2
     mock_download_archive.call_count == 2
-    mock_get_checksum.call_count == 2
+    mock_calculate_checksum.call_count == 2
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
@@ -101,7 +101,7 @@ def test_run_github_action(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -109,7 +109,7 @@ def test_run_github_action_update_readme(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,
@@ -127,7 +127,7 @@ def test_run_github_action_update_readme(
     mock_check_env_variables.assert_called_once()
     assert mock_make_github_get_request.call_count == 2
     mock_download_archive.call_count == 2
-    mock_get_checksum.call_count == 2
+    mock_calculate_checksum.call_count == 2
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
@@ -147,7 +147,7 @@ def test_run_github_action_update_readme(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -157,7 +157,7 @@ def test_run_github_action_update_python_resources(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,
@@ -174,7 +174,7 @@ def test_run_github_action_update_python_resources(
     mock_check_env_variables.assert_called_once()
     assert mock_make_github_get_request.call_count == 2
     mock_download_archive.call_count == 2
-    mock_get_checksum.call_count == 2
+    mock_calculate_checksum.call_count == 2
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()
@@ -197,7 +197,7 @@ def test_run_github_action_update_python_resources(
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -205,7 +205,7 @@ def test_run_github_action_target_matrix(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,
@@ -223,7 +223,7 @@ def test_run_github_action_target_matrix(
     mock_check_env_variables.assert_called_once()
     assert mock_make_github_get_request.call_count == 2
     mock_download_archive.call_count == 2
-    mock_get_checksum.call_count == 2
+    mock_calculate_checksum.call_count == 2
     mock_generate_formula.assert_called_once()
     mock_write_file.call_count == 2
     mock_setup_git.assert_called_once()

--- a/test/unit/test_checksum.py
+++ b/test/unit/test_checksum.py
@@ -10,9 +10,10 @@ import requests
 from homebrew_releaser.checksum import Checksum
 
 
-def test_get_checksum():
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
+def test_calculate_checksum():
     """Tests that we can get the checksum of a file (we use one that will never change)."""
-    checksum = Checksum.get_checksum('homebrew_releaser/__init__.py')
+    checksum = Checksum.calculate_checksum('homebrew_releaser/__init__.py')
 
     assert checksum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
@@ -20,9 +21,9 @@ def test_get_checksum():
 @patch(
     'subprocess.check_output', side_effect=subprocess.CalledProcessError(returncode=1, cmd='subprocess.check_output')
 )
-def test_get_checksum_process_error(mock_subprocess, mock_tar_filename):
+def test_calculate_checksum_process_error(mock_subprocess, mock_tar_filename):
     with pytest.raises(SystemExit):
-        Checksum.get_checksum(mock_tar_filename)
+        Checksum.calculate_checksum(mock_tar_filename)
 
 
 @patch('requests.post')

--- a/test/unit/test_checksum.py
+++ b/test/unit/test_checksum.py
@@ -8,26 +8,13 @@ import pytest
 import requests
 
 from homebrew_releaser.checksum import Checksum
-from homebrew_releaser.constants import TIMEOUT
 
 
-@patch('subprocess.check_output')
-def test_get_checksum(mock_subprocess, mock_tar_filename):
-    # TODO: Mock the subprocess better to ensure it does what it's supposed to
-    Checksum.get_checksum(mock_tar_filename)
+def test_get_checksum():
+    """Tests that we can get the checksum of a file (we use one that will never change)."""
+    checksum = Checksum.get_checksum('homebrew_releaser/__init__.py')
 
-    mock_subprocess.assert_called_once_with(
-        ['shasum', '-a', '256', mock_tar_filename],
-        stdin=None,
-        stderr=None,
-        timeout=TIMEOUT,
-    )
-
-
-@patch('subprocess.check_output', side_effect=subprocess.TimeoutExpired(cmd='subprocess.check_output', timeout=0.1))
-def test_get_checksum_subprocess_timeout(mock_subprocess, mock_tar_filename):
-    with pytest.raises(SystemExit):
-        Checksum.get_checksum(mock_tar_filename)
+    assert checksum == 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 
 
 @patch(

--- a/test/unit/test_formula.py
+++ b/test/unit/test_formula.py
@@ -953,6 +953,6 @@ def test_update_python_resources_error(mock_subprocess, mock_which):
         f'cd {FORMULA_PATH} && {brew_path} update-python-resources {formula_name}',
         stderr=subprocess.STDOUT,
         text=True,
-        timeout=60,
+        timeout=300,
         shell=True,
     )

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -10,6 +10,7 @@ from homebrew_releaser.constants import TIMEOUT
 from homebrew_releaser.git import Git
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('homebrew_releaser.git.GITHUB_TOKEN', '123')
 @patch('subprocess.check_output')
 def test_setup(mock_subprocess):
@@ -27,6 +28,7 @@ def test_setup(mock_subprocess):
                     'clone',
                     '--depth=1',
                     'https://x-access-token:123@github.com/Justintime50/homebrew-formulas.git',
+                    'homebrew-formulas',
                 ],
                 stderr=-2,
                 text=True,
@@ -48,6 +50,7 @@ def test_setup(mock_subprocess):
     )
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('subprocess.check_output')
 def test_add(mock_subprocess):
     """Tests that we call the correct git add command."""
@@ -62,6 +65,7 @@ def test_add(mock_subprocess):
     )
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('subprocess.check_output')
 def test_commit(mock_subprocess):
     """Tests that we call the correct git commit command."""
@@ -78,6 +82,7 @@ def test_commit(mock_subprocess):
     )
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('homebrew_releaser.git.GITHUB_TOKEN', '123')
 @patch('subprocess.check_output')
 def test_push(mock_subprocess):

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -30,19 +30,19 @@ def test_setup(mock_subprocess):
                 ],
                 stderr=-2,
                 text=True,
-                timeout=60,
+                timeout=300,
             ),
             call(
                 ['git', '-C', 'homebrew-formulas', 'config', 'user.name', '"Justintime50"'],
                 stderr=-2,
                 text=True,
-                timeout=60,
+                timeout=300,
             ),
             call(
                 ['git', '-C', 'homebrew-formulas', 'config', 'user.email', 'user@example.com'],
                 stderr=-2,
                 text=True,
-                timeout=60,
+                timeout=300,
             ),
         ]
     )

--- a/test/unit/test_github_action_config.py
+++ b/test/unit/test_github_action_config.py
@@ -16,7 +16,7 @@ from homebrew_releaser.app import App
 @patch('homebrew_releaser.git.Git.push')
 @patch('homebrew_releaser.utils.Utils.write_file')
 @patch('homebrew_releaser.formula.Formula.generate_formula_data')
-@patch('homebrew_releaser.checksum.Checksum.get_checksum', return_value=('123', 'mock-repo'))
+@patch('homebrew_releaser.checksum.Checksum.calculate_checksum', return_value=('123', 'mock-repo'))
 @patch('homebrew_releaser.app.App.download_archive')
 @patch('homebrew_releaser.utils.Utils.make_github_get_request')
 @patch('homebrew_releaser.app.App.check_required_env_variables')
@@ -24,7 +24,7 @@ def test_run_github_action_string_false_config(
     mock_check_env_variables,
     mock_make_github_get_request,
     mock_download_archive,
-    mock_get_checksum,
+    mock_calculate_checksum,
     mock_generate_formula,
     mock_write_file,
     mock_push_formula,

--- a/test/unit/test_readme_updater.py
+++ b/test/unit/test_readme_updater.py
@@ -55,6 +55,7 @@ def test_update_readme_cannot_find_old_table(
     mock_replace_table_contents.assert_not_called()
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('homebrew_releaser.readme_updater.FORMULA_FOLDER', 'test/unit')
 def test_format_formula_data_no_ruby_files():
     """Tests that we throw an error when the formula folder provided does not contain any
@@ -66,6 +67,7 @@ def test_format_formula_data_no_ruby_files():
     assert str(error.value) == 'No Ruby files found in the "formula_folder" provided.'
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('homebrew_releaser.readme_updater.FORMULA_FOLDER', 'formulas')
 def test_format_formula_data():
     """Tests that we build a list of formula metadata correctly based on what we found in the repo.
@@ -83,6 +85,7 @@ def test_format_formula_data():
     }
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('homebrew_releaser.readme_updater.FORMULA_FOLDER', 'formulas')
 def test_format_formula_data_error_reading_formula():
     """Tests that we throw an error when we cannot properly read formula data."""
@@ -116,6 +119,7 @@ def test_generate_table():
     # fmt: on
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 def test_retrieve_old_table_not_found():
     """Tests that we set the `table_found` variable to False when we can't find opening/closing README tags."""
     old_table, old_table_found = ReadmeUpdater.retrieve_old_table('./')
@@ -148,6 +152,7 @@ def test_retrieve_old_table(table_content):
     assert old_table_found is True
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 @patch('logging.Logger.error')
 def test_retrieve_old_table_no_readme(mock_logger):
     """Tests that we retrieve only the old table data when start and end tags exist."""
@@ -165,6 +170,7 @@ def test_read_current_readme_does_not_exist():
     assert readme == ""
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 def test_read_current_readme():
     """Tests that the content of a README found is returned."""
     readme = ReadmeUpdater.read_current_readme('./')
@@ -197,6 +203,7 @@ def test_replace_table_contents_no_readme(mock_git_add, mock_logger):
     mock_logger.assert_not_called()
 
 
+@patch('homebrew_releaser.utils.WORKING_DIR', '')
 def test_does_readme_exist():
     """Tests that we can find a README in a directory."""
     readme = ReadmeUpdater.does_readme_exist('./')

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -20,7 +20,7 @@ def test_make_github_get_request(mock_request):
         headers=GITHUB_HEADERS,
         allow_redirects=True,
         stream=False,
-        timeout=60,
+        timeout=300,
     )
 
 
@@ -38,7 +38,7 @@ def test_make_github_get_request_stream(mock_request):
         headers=headers,
         allow_redirects=True,
         stream=True,
-        timeout=60,
+        timeout=300,
     )
 
 


### PR DESCRIPTION
Closes #58 by using full paths to Python in the Dockerfile. Also adjusts tests to greatly protect against regressions by mimicking GitHub Actions environment much more closely (still not perfect). Finally had to use `tmp` dir from now on due to limitations of permissions (see README).