### PR TITLE
fix: copy formula to FORMULA_FOLDER instead of repository root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,15 @@ RUN \
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | \
         su - linuxbrew -c "NONINTERACTIVE=1 /bin/bash" && \
     su - linuxbrew -c "git -C /home/linuxbrew/.linuxbrew/Homebrew checkout 5.0.4" && \
-    chown linuxbrew:linuxbrew /app
+    chown -R linuxbrew:linuxbrew /app
 
 USER linuxbrew
-
-RUN brew install python@3.14
 
 COPY pyproject.toml .
 COPY homebrew_releaser homebrew_releaser
 
-RUN python3 -m venv venv && \
+RUN brew install python@3.14 && \
+    python3 -m venv venv && \
     venv/bin/pip install .
 
 ENTRYPOINT ["/app/venv/bin/python", "/app/homebrew_releaser/app.py"]

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -185,7 +185,9 @@ def run_github_action():
     )
 
     formula_filename = f'{repository["name"]}.rb'
-    formula_dir = f"/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/{HOMEBREW_OWNER}/{HOMEBREW_TAP}"
+    formula_dir = os.path.join(
+        "home", "linuxbrew", ".linuxbrew", "Homebrew", "Library", "Taps", HOMEBREW_OWNER, HOMEBREW_TAP
+    )
     formula_filepath = os.path.join(formula_dir, formula_filename)
     write_file(formula_filepath, template, "w")
 

--- a/homebrew_releaser/app.py
+++ b/homebrew_releaser/app.py
@@ -186,7 +186,13 @@ def run_github_action():
 
     formula_filename = f'{repository["name"]}.rb'
     formula_dir = os.path.join(
-        "home", "linuxbrew", ".linuxbrew", "Homebrew", "Library", "Taps", HOMEBREW_OWNER, HOMEBREW_TAP
+        os.path.expanduser("~"),  # Linuxbrew home directory
+        ".linuxbrew",
+        "Homebrew",
+        "Library",
+        "Taps",
+        HOMEBREW_OWNER,
+        HOMEBREW_TAP,
     )
     formula_filepath = os.path.join(formula_dir, formula_filename)
     write_file(formula_filepath, template, "w")

--- a/homebrew_releaser/checksum.py
+++ b/homebrew_releaser/checksum.py
@@ -12,7 +12,7 @@ from homebrew_releaser.constants import (
     LOGGER_NAME,
     TIMEOUT,
 )
-from homebrew_releaser.utils import get_working_dir
+from homebrew_releaser.utils import build_dir_path
 
 
 def calculate_checksum(tar_filepath: str) -> str:
@@ -20,7 +20,7 @@ def calculate_checksum(tar_filepath: str) -> str:
     logger = woodchips.get(LOGGER_NAME)
 
     try:
-        with open(get_working_dir(tar_filepath), "rb") as content:
+        with open(build_dir_path(tar_filepath), "rb") as content:
             checksum = hashlib.sha256(content.read()).hexdigest()
         logger.debug(f"Checksum for {tar_filepath} generated successfully: {checksum}")
     except Exception as error:
@@ -35,7 +35,7 @@ def upload_checksum_file(latest_release: dict[str, Any]):
 
     latest_release_id = latest_release["id"]
 
-    with open(get_working_dir(CHECKSUM_FILE), "rb") as filename:
+    with open(build_dir_path(CHECKSUM_FILE), "rb") as filename:
         checksum_file_content = filename.read()
 
     upload_url = f"https://uploads.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/{latest_release_id}/assets?name={CHECKSUM_FILE}"  # noqa

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -27,7 +27,7 @@ GITHUB_HEADERS = {
     "Authorization": f"Bearer {GITHUB_TOKEN}",
 }
 CHECKSUM_FILE = "checksum.txt"
-WORKING_DIR = "/app"  # nosec
+WORKING_DIR = "app"
 
 # Formula Constants
 ARTICLES = {

--- a/homebrew_releaser/constants.py
+++ b/homebrew_releaser/constants.py
@@ -27,7 +27,7 @@ GITHUB_HEADERS = {
     "Authorization": f"Bearer {GITHUB_TOKEN}",
 }
 CHECKSUM_FILE = "checksum.txt"
-WORKING_DIR = "app"
+WORKING_DIR = os.path.join(os.sep, "app")
 
 # Formula Constants
 ARTICLES = {

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -4,6 +4,7 @@ from typing import Optional
 import woodchips
 
 from homebrew_releaser.constants import (
+    FORMULA_FOLDER,
     GITHUB_TOKEN,
     LOGGER_NAME,
     TIMEOUT,
@@ -40,7 +41,7 @@ def setup_git(commit_owner: str, commit_email: str, homebrew_owner: str, homebre
 
 def copy_formula_file_to_git(formula_filepath: str, homebrew_tap: str):
     """Copies the formula file from the official homebrew tap to the source code homebrew tap."""
-    command = ["cp", formula_filepath, get_working_dir(homebrew_tap)]
+    command = ["cp", formula_filepath, get_working_dir(homebrew_tap, FORMULA_FOLDER)]
     _run_git_subprocess(command, "Formula file moved to git repo successfully.")
 
 

--- a/homebrew_releaser/git.py
+++ b/homebrew_releaser/git.py
@@ -9,7 +9,7 @@ from homebrew_releaser.constants import (
     LOGGER_NAME,
     TIMEOUT,
 )
-from homebrew_releaser.utils import get_working_dir
+from homebrew_releaser.utils import build_dir_path
 
 
 def setup_git(commit_owner: str, commit_email: str, homebrew_owner: str, homebrew_tap: str):
@@ -27,10 +27,10 @@ def setup_git(commit_owner: str, commit_email: str, homebrew_owner: str, homebre
             "clone",
             "--depth=1",
             f"https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git",
-            get_working_dir(homebrew_tap),
+            build_dir_path(homebrew_tap),
         ],
-        ["git", "-C", get_working_dir(homebrew_tap), "config", "user.name", f'"{commit_owner}"'],
-        ["git", "-C", get_working_dir(homebrew_tap), "config", "user.email", commit_email],
+        ["git", "-C", build_dir_path(homebrew_tap), "config", "user.name", f'"{commit_owner}"'],
+        ["git", "-C", build_dir_path(homebrew_tap), "config", "user.email", commit_email],
     ]
 
     for command in commands:
@@ -41,21 +41,21 @@ def setup_git(commit_owner: str, commit_email: str, homebrew_owner: str, homebre
 
 def copy_formula_file_to_git(formula_filepath: str, homebrew_tap: str):
     """Copies the formula file from the official homebrew tap to the source code homebrew tap."""
-    command = ["cp", formula_filepath, get_working_dir(homebrew_tap, FORMULA_FOLDER)]
+    command = ["cp", formula_filepath, build_dir_path(homebrew_tap, FORMULA_FOLDER)]
     _run_git_subprocess(command, "Formula file moved to git repo successfully.")
 
 
 def add_git(homebrew_tap: str):
     """Adds git assets to a git commit."""
     # We add everything here because we updated the formula file and optionally the README
-    command = ["git", "-C", get_working_dir(homebrew_tap), "add", "."]
+    command = ["git", "-C", build_dir_path(homebrew_tap), "add", "."]
     _run_git_subprocess(command, "Assets added to git commit successfully.")
 
 
 def commit_git(homebrew_tap: str, repo_name: str, version: str):
     """Commits git assets to the Homebrew tap repo."""
     # fmt: off
-    command = ['git', '-C', get_working_dir(homebrew_tap), 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
+    command = ['git', '-C', build_dir_path(homebrew_tap), 'commit', '-m', f'chore: brew formula update for {repo_name} {version}']  # noqa
     # fmt: on
     _run_git_subprocess(command, "Assets committed successfully.")
 
@@ -63,7 +63,7 @@ def commit_git(homebrew_tap: str, repo_name: str, version: str):
 def push_git(homebrew_tap: str, homebrew_owner: str):
     """Pushes git assets to the remote Homebrew tap repo."""
     # fmt: off
-    command = ['git', '-C', get_working_dir(homebrew_tap), 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
+    command = ['git', '-C', build_dir_path(homebrew_tap), 'push', f'https://x-access-token:{GITHUB_TOKEN}@github.com/{homebrew_owner}/{homebrew_tap}.git']  # noqa
     # fmt: on
     _run_git_subprocess(command, f"Assets pushed successfully to {homebrew_tap}.")
 

--- a/homebrew_releaser/readme_updater.py
+++ b/homebrew_releaser/readme_updater.py
@@ -13,7 +13,7 @@ from homebrew_releaser.constants import (
     FORMULA_FOLDER,
     LOGGER_NAME,
 )
-from homebrew_releaser.utils import get_working_dir
+from homebrew_releaser.utils import build_dir_path
 
 
 TABLE_START_TAG = "<!-- project_table_start -->"
@@ -39,16 +39,15 @@ def _format_formula_data(homebrew_tap: str) -> list[dict[str, Any]]:
     """Retrieve the name, description, and homepage from each
     Ruby formula file in the homebrew tap repo.
     """
-    homebrew_tap_path = get_working_dir(os.path.join(homebrew_tap, FORMULA_FOLDER))
     formulas = []
-    files = os.listdir(homebrew_tap_path)
+    files = os.listdir(build_dir_path(homebrew_tap, FORMULA_FOLDER))
 
     if not any([file.endswith(".rb") for file in files]):
         raise SystemExit('No Ruby files found in the "formula_folder" provided.')
 
     try:
         for filename in sorted(files):
-            with open(os.path.join(homebrew_tap_path, filename), "r") as formula:
+            with open(build_dir_path(homebrew_tap, FORMULA_FOLDER, filename), "r") as formula:
                 # Set empty defaults
                 final_name = ""
                 final_desc = ""
@@ -123,7 +122,7 @@ def _retrieve_old_table(homebrew_tap: str) -> Tuple[str, bool]:
     old_table = ""
 
     if readme:
-        with open(get_working_dir(readme), "r") as readme_contents:
+        with open(build_dir_path(readme), "r") as readme_contents:
             for line in readme_contents:
                 normalized_line = line.strip().lower()
                 if normalized_line == TABLE_START_TAG:
@@ -157,7 +156,7 @@ def _read_current_readme(homebrew_tap: str) -> str:
     file_content = ""
 
     if readme:
-        with open(get_working_dir(readme), "r") as readme_contents:
+        with open(build_dir_path(readme), "r") as readme_contents:
             file_content = readme_contents.read()
         logger.debug(f"{readme} read successfully.")
 
@@ -173,7 +172,7 @@ def _replace_table_contents(file_content: str, old_table: str, new_table: str, h
     readme = _does_readme_exist(homebrew_tap)
 
     if readme:
-        with open(get_working_dir(readme), "w") as readme_contents:
+        with open(build_dir_path(readme), "w") as readme_contents:
             readme_contents.write(file_content.replace(old_table, new_table))
         logger.debug(f"{readme} table updated successfully.")
 
@@ -186,12 +185,11 @@ def _does_readme_exist(homebrew_tap: str) -> Optional[str]:
     """
     readme_to_open = None
     readme_filename = "readme.md"
-    tap_dir = get_working_dir(homebrew_tap)
-    files = os.listdir(tap_dir)
+    files = os.listdir(build_dir_path(homebrew_tap))
 
     for filename in files:
         if filename.lower() == readme_filename:
-            readme_to_open = os.path.join(tap_dir, filename)
+            readme_to_open = build_dir_path(homebrew_tap, filename)
             break
 
     return readme_to_open

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -53,6 +53,6 @@ def get_filename_from_path(path: str) -> str:
     return path.rsplit("/", 1)[1]
 
 
-def get_working_dir(additional_path: str) -> str:
+def get_working_dir(*additional_path: str) -> str:
     """Gets the working directory."""
-    return os.path.join(WORKING_DIR, additional_path)
+    return os.path.join(WORKING_DIR, *additional_path)

--- a/homebrew_releaser/utils.py
+++ b/homebrew_releaser/utils.py
@@ -41,7 +41,7 @@ def write_file(file_path: str, content: str | bytes, mode: str = "w"):
     logger = woodchips.get(LOGGER_NAME)
 
     try:
-        with open(get_working_dir(file_path), mode) as f:
+        with open(build_dir_path(file_path), mode) as f:
             f.write(content)
         logger.debug(f"{file_path} written successfully.")
     except Exception as error:
@@ -53,6 +53,6 @@ def get_filename_from_path(path: str) -> str:
     return path.rsplit("/", 1)[1]
 
 
-def get_working_dir(*additional_path: str) -> str:
-    """Gets the working directory."""
-    return os.path.join(WORKING_DIR, *additional_path)
+def build_dir_path(*paths: str) -> str:
+    """Builds a directory path relative to the working directory."""
+    return os.path.join(WORKING_DIR, *paths)

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -65,7 +65,7 @@ def test_copy_formula_file_to_git(mock_subprocess):
 
     copy_formula_file_to_git(formula_filepath, homebrew_tap)
     mock_subprocess.assert_called_once_with(
-        ["cp", "/path/to/formula.rb", "homebrew-formulas"],
+        ["cp", "/path/to/formula.rb", "homebrew-formulas/Formula"],
         stderr=-2,
         text=True,
         timeout=TIMEOUT,


### PR DESCRIPTION
Homebrew warns if the formula isn't in the "Formula" folder. Worse, if the same formula exists in the repo root and also the Formula folder, the Formula folder is preferred and changes pushed by homebrew-releaser aren't picked up.